### PR TITLE
[YAF-76] Initialize Hexagonal Architecture and Separate Domain Models

### DIFF
--- a/src/main/java/co/yapp/orbit/fortune/adapter/in/FortuneController.java
+++ b/src/main/java/co/yapp/orbit/fortune/adapter/in/FortuneController.java
@@ -1,0 +1,8 @@
+package co.yapp.orbit.fortune.adapter.in;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class FortuneController {
+
+}

--- a/src/main/java/co/yapp/orbit/fortune/adapter/out/FortuneEntity.java
+++ b/src/main/java/co/yapp/orbit/fortune/adapter/out/FortuneEntity.java
@@ -1,0 +1,11 @@
+package co.yapp.orbit.fortune.adapter.out;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class FortuneEntity {
+
+    @Id
+    private Long id;
+}

--- a/src/main/java/co/yapp/orbit/fortune/adapter/out/FortunePersistenceAdapter.java
+++ b/src/main/java/co/yapp/orbit/fortune/adapter/out/FortunePersistenceAdapter.java
@@ -1,0 +1,14 @@
+package co.yapp.orbit.fortune.adapter.out;
+
+import co.yapp.orbit.fortune.application.port.out.LoadFortunePort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FortunePersistenceAdapter implements LoadFortunePort {
+
+    private final FortuneRepository fortuneRepository;
+
+    public FortunePersistenceAdapter(FortuneRepository fortuneRepository) {
+        this.fortuneRepository = fortuneRepository;
+    }
+}

--- a/src/main/java/co/yapp/orbit/fortune/adapter/out/FortuneRepository.java
+++ b/src/main/java/co/yapp/orbit/fortune/adapter/out/FortuneRepository.java
@@ -1,8 +1,7 @@
 package co.yapp.orbit.fortune.adapter.out;
 
-import co.yapp.orbit.fortune.domain.Fortune;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FortuneRepository extends JpaRepository<Fortune, Long> {
+public interface FortuneRepository extends JpaRepository<FortuneEntity, Long> {
 
 }

--- a/src/main/java/co/yapp/orbit/fortune/adapter/out/FortuneRepository.java
+++ b/src/main/java/co/yapp/orbit/fortune/adapter/out/FortuneRepository.java
@@ -1,0 +1,8 @@
+package co.yapp.orbit.fortune.adapter.out;
+
+import co.yapp.orbit.fortune.domain.Fortune;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FortuneRepository extends JpaRepository<Fortune, Long> {
+
+}

--- a/src/main/java/co/yapp/orbit/fortune/application/FortuneService.java
+++ b/src/main/java/co/yapp/orbit/fortune/application/FortuneService.java
@@ -1,0 +1,15 @@
+package co.yapp.orbit.fortune.application;
+
+import co.yapp.orbit.fortune.application.port.in.GetFortuneUseCase;
+import co.yapp.orbit.fortune.application.port.out.LoadFortunePort;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FortuneService implements GetFortuneUseCase {
+
+    private final LoadFortunePort loadFortunePort;
+
+    public FortuneService(LoadFortunePort loadFortunePort) {
+        this.loadFortunePort = loadFortunePort;
+    }
+}

--- a/src/main/java/co/yapp/orbit/fortune/application/FortuneService.java
+++ b/src/main/java/co/yapp/orbit/fortune/application/FortuneService.java
@@ -1,11 +1,11 @@
 package co.yapp.orbit.fortune.application;
 
-import co.yapp.orbit.fortune.application.port.in.GetFortuneUseCase;
+import co.yapp.orbit.fortune.application.port.in.LoadFortuneUseCase;
 import co.yapp.orbit.fortune.application.port.out.LoadFortunePort;
 import org.springframework.stereotype.Service;
 
 @Service
-public class FortuneService implements GetFortuneUseCase {
+public class FortuneService implements LoadFortuneUseCase {
 
     private final LoadFortunePort loadFortunePort;
 

--- a/src/main/java/co/yapp/orbit/fortune/application/port/in/GetFortuneUseCase.java
+++ b/src/main/java/co/yapp/orbit/fortune/application/port/in/GetFortuneUseCase.java
@@ -1,0 +1,4 @@
+package co.yapp.orbit.fortune.application.port.in;
+
+public interface GetFortuneUseCase {
+}

--- a/src/main/java/co/yapp/orbit/fortune/application/port/in/LoadFortuneCommand.java
+++ b/src/main/java/co/yapp/orbit/fortune/application/port/in/LoadFortuneCommand.java
@@ -1,4 +1,5 @@
 package co.yapp.orbit.fortune.application.port.in;
 
-public interface GetFortuneUseCase {
+public class LoadFortuneCommand {
+
 }

--- a/src/main/java/co/yapp/orbit/fortune/application/port/in/LoadFortuneUseCase.java
+++ b/src/main/java/co/yapp/orbit/fortune/application/port/in/LoadFortuneUseCase.java
@@ -1,0 +1,4 @@
+package co.yapp.orbit.fortune.application.port.in;
+
+public interface LoadFortuneUseCase {
+}

--- a/src/main/java/co/yapp/orbit/fortune/application/port/out/LoadFortunePort.java
+++ b/src/main/java/co/yapp/orbit/fortune/application/port/out/LoadFortunePort.java
@@ -1,0 +1,4 @@
+package co.yapp.orbit.fortune.application.port.out;
+
+public interface LoadFortunePort {
+}

--- a/src/main/java/co/yapp/orbit/fortune/domain/Fortune.java
+++ b/src/main/java/co/yapp/orbit/fortune/domain/Fortune.java
@@ -1,0 +1,11 @@
+package co.yapp.orbit.fortune.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Fortune {
+
+    @Id
+    private Long id;
+}

--- a/src/main/java/co/yapp/orbit/fortune/domain/Fortune.java
+++ b/src/main/java/co/yapp/orbit/fortune/domain/Fortune.java
@@ -1,11 +1,5 @@
 package co.yapp.orbit.fortune.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-
-@Entity
 public class Fortune {
 
-    @Id
-    private Long id;
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
@@ -1,0 +1,8 @@
+package co.yapp.orbit.user.adapter.in;
+
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+}

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
@@ -1,0 +1,11 @@
+package co.yapp.orbit.user.adapter.out;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class UserEntity {
+
+    @Id
+    private Long id;
+}

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapter.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapter.java
@@ -1,0 +1,15 @@
+package co.yapp.orbit.user.adapter.out;
+
+import co.yapp.orbit.user.application.port.out.LoadUserPort;
+import co.yapp.orbit.user.application.port.out.SaveUserPort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserPersistenceAdapter implements LoadUserPort, SaveUserPort {
+
+    private final UserRepository userRepository;
+
+    public UserPersistenceAdapter(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserRepository.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserRepository.java
@@ -1,0 +1,8 @@
+package co.yapp.orbit.user.adapter.out;
+
+import co.yapp.orbit.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserRepository.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserRepository.java
@@ -1,8 +1,7 @@
 package co.yapp.orbit.user.adapter.out;
 
-import co.yapp.orbit.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
 }

--- a/src/main/java/co/yapp/orbit/user/application/LoadUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/LoadUserService.java
@@ -1,0 +1,15 @@
+package co.yapp.orbit.user.application;
+
+import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
+import co.yapp.orbit.user.application.port.out.LoadUserPort;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LoadUserService implements LoadUserUseCase {
+
+    private final LoadUserPort loadUserPort;
+
+    public LoadUserService(LoadUserPort loadUserPort) {
+        this.loadUserPort = loadUserPort;
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
@@ -1,0 +1,15 @@
+package co.yapp.orbit.user.application;
+
+import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
+import co.yapp.orbit.user.application.port.out.SaveUserPort;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SaveUserService implements SaveUserUseCase {
+
+    private final SaveUserPort saveUserPort;
+
+    public SaveUserService(SaveUserPort saveUserPort) {
+        this.saveUserPort = saveUserPort;
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/in/LoadUserUseCase.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/LoadUserUseCase.java
@@ -1,0 +1,5 @@
+package co.yapp.orbit.user.application.port.in;
+
+public interface LoadUserUseCase {
+
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserCommand.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserCommand.java
@@ -1,0 +1,5 @@
+package co.yapp.orbit.user.application.port.in;
+
+public class SaveUserCommand {
+
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserUseCase.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserUseCase.java
@@ -1,0 +1,5 @@
+package co.yapp.orbit.user.application.port.in;
+
+public interface SaveUserUseCase {
+
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/out/LoadUserPort.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/out/LoadUserPort.java
@@ -1,0 +1,4 @@
+package co.yapp.orbit.user.application.port.out;
+
+public interface LoadUserPort {
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/out/SaveUserPort.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/out/SaveUserPort.java
@@ -1,0 +1,5 @@
+package co.yapp.orbit.user.application.port.out;
+
+public interface SaveUserPort {
+
+}

--- a/src/main/java/co/yapp/orbit/user/domain/User.java
+++ b/src/main/java/co/yapp/orbit/user/domain/User.java
@@ -1,11 +1,5 @@
 package co.yapp.orbit.user.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-
-@Entity
 public class User {
 
-    @Id
-    private Long id;
 }

--- a/src/main/java/co/yapp/orbit/user/domain/User.java
+++ b/src/main/java/co/yapp/orbit/user/domain/User.java
@@ -1,0 +1,11 @@
+package co.yapp.orbit.user.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class User {
+
+    @Id
+    private Long id;
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #<YAF-76>

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [x] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- Fortune 및 User 도메인에 대한 헥사고날 아키텍처 기본 스켈레톤을 추가했습니다.
- 도메인 모델(User, Fortune)에서 JPA 어노테이션을 제거하고, 별도의 엔티티(UserEntity, FortuneEntity)를 생성했습니다.

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
- 추후 구현을 진행하면서 필요한 사항에 따라 패키지 구조를 수정해 주시면 됩니다. 현재는 기본적인 패키지 구조만 설정하였습니다.