### PR TITLE
[YAF-99] Add PreReservation API with Domain, Persistence, and Tests

### DIFF
--- a/src/main/java/co/yapp/orbit/prereservation/adapter/in/PreReservationController.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/in/PreReservationController.java
@@ -1,8 +1,8 @@
 package co.yapp.orbit.prereservation.adapter.in;
 
+import co.yapp.orbit.prereservation.adapter.in.request.PreReservationCreateRequest;
 import co.yapp.orbit.prereservation.application.port.in.CreatePreReservationUseCase;
 import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,18 +20,12 @@ public class PreReservationController {
     }
 
     @PostMapping
-    public ResponseEntity<?> createPreReservation(@RequestBody PreReservationCommand command) {
-        try {
-            createPreReservationUseCase.createPreReservation(command);
-            return ResponseEntity.ok().build();
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity
-                .status(HttpStatus.CONFLICT)
-                .body(e.getMessage());
-        } catch (Exception e) {
-            return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(e.getMessage());
-        }
+    public ResponseEntity<?> createPreReservation(@RequestBody PreReservationCreateRequest request) {
+        PreReservationCommand command = new PreReservationCommand(
+            request.getName(),
+            request.getPhoneNumber()
+        );
+        createPreReservationUseCase.createPreReservation(command);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/in/PreReservationController.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/in/PreReservationController.java
@@ -1,0 +1,37 @@
+package co.yapp.orbit.prereservation.adapter.in;
+
+import co.yapp.orbit.prereservation.application.port.in.CreatePreReservationUseCase;
+import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/v1/prereservations")
+@RestController
+public class PreReservationController {
+
+    private final CreatePreReservationUseCase createPreReservationUseCase;
+
+    public PreReservationController(CreatePreReservationUseCase createPreReservationUseCase) {
+        this.createPreReservationUseCase = createPreReservationUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createPreReservation(@RequestBody PreReservationCommand command) {
+        try {
+            createPreReservationUseCase.createPreReservation(command);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/in/exception/PreReservationExceptionHandler.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/in/exception/PreReservationExceptionHandler.java
@@ -2,28 +2,33 @@ package co.yapp.orbit.prereservation.adapter.in.exception;
 
 import co.yapp.orbit.prereservation.application.exception.DuplicatePreReservationException;
 import co.yapp.orbit.prereservation.application.exception.InvalidPreReservationCommandException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice(basePackages = "co.yapp.orbit.prereservation.adapter.in")
 public class PreReservationExceptionHandler {
 
     @ExceptionHandler(InvalidPreReservationCommandException.class)
     public ResponseEntity<String> handleInvalidPreReservationCommandException(InvalidPreReservationCommandException e) {
+        log.error("Invalid PreReservation Command Exception occurred: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(e.getMessage());
     }
 
     @ExceptionHandler(DuplicatePreReservationException.class)
     public ResponseEntity<String> handleDuplicatePreReservationException(DuplicatePreReservationException e) {
+        log.error("Duplicate PreReservation Exception occurred: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.CONFLICT)
             .body(e.getMessage());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(Exception e) {
+        log.error("Unhandled Exception occurred: {}", e.getMessage(), e);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(e.getMessage());
     }

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/in/exception/PreReservationExceptionHandler.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/in/exception/PreReservationExceptionHandler.java
@@ -1,0 +1,30 @@
+package co.yapp.orbit.prereservation.adapter.in.exception;
+
+import co.yapp.orbit.prereservation.application.exception.DuplicatePreReservationException;
+import co.yapp.orbit.prereservation.application.exception.InvalidPreReservationCommandException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "co.yapp.orbit.prereservation.adapter.in")
+public class PreReservationExceptionHandler {
+
+    @ExceptionHandler(InvalidPreReservationCommandException.class)
+    public ResponseEntity<String> handleInvalidPreReservationCommandException(InvalidPreReservationCommandException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(e.getMessage());
+    }
+
+    @ExceptionHandler(DuplicatePreReservationException.class)
+    public ResponseEntity<String> handleDuplicatePreReservationException(DuplicatePreReservationException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(e.getMessage());
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/in/request/PreReservationCreateRequest.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/in/request/PreReservationCreateRequest.java
@@ -1,0 +1,18 @@
+package co.yapp.orbit.prereservation.adapter.in.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PreReservationCreateRequest {
+
+    private String name;
+
+    private String phoneNumber;
+
+    public PreReservationCreateRequest(String name, String phoneNumber) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationEntity.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationEntity.java
@@ -1,0 +1,30 @@
+package co.yapp.orbit.prereservation.adapter.out;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "pre_reservation")
+public class PreReservationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String phoneNumber;
+
+    protected PreReservationEntity() {
+    }
+
+    public PreReservationEntity(String name, String phoneNumber) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapter.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapter.java
@@ -1,0 +1,29 @@
+package co.yapp.orbit.prereservation.adapter.out;
+
+import co.yapp.orbit.prereservation.application.port.out.SavePreReservationPort;
+import co.yapp.orbit.prereservation.domain.PreReservation;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PreReservationPersistenceAdapter implements SavePreReservationPort {
+
+    private final PreReservationRepository preReservationRepository;
+
+    public PreReservationPersistenceAdapter(PreReservationRepository preReservationRepository) {
+        this.preReservationRepository = preReservationRepository;
+    }
+
+    @Override
+    public boolean existsByNameAndPhoneNumber(String name, String phoneNumber) {
+        return preReservationRepository.existsByNameAndPhoneNumber(name, phoneNumber);
+    }
+
+    @Override
+    public void save(PreReservation preReservation) {
+        PreReservationEntity entity = new PreReservationEntity(
+            preReservation.getName(),
+            preReservation.getPhoneNumber()
+        );
+        preReservationRepository.save(entity);
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationRepository.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationRepository.java
@@ -1,0 +1,7 @@
+package co.yapp.orbit.prereservation.adapter.out;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PreReservationRepository extends JpaRepository<PreReservationEntity, Long> {
+    boolean existsByNameAndPhoneNumber(String name, String phoneNumber);
+}

--- a/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
@@ -1,5 +1,6 @@
 package co.yapp.orbit.prereservation.application;
 
+import co.yapp.orbit.prereservation.application.exception.DuplicatePreReservationException;
 import co.yapp.orbit.prereservation.application.port.in.CreatePreReservationUseCase;
 import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
 import co.yapp.orbit.prereservation.application.port.out.SavePreReservationPort;
@@ -19,11 +20,14 @@ public class PreReservationService implements CreatePreReservationUseCase {
     @Transactional
     @Override
     public void createPreReservation(PreReservationCommand command) {
-        if (savePreReservationPort.existsByNameAndPhoneNumber(command.getName(), command.getPhoneNumber())) {
-            throw new IllegalArgumentException("이미 동일한 이름과 전화번호로 사전예약이 존재합니다.");
+        if (checkDuplicate(command.getName(), command.getPhoneNumber())) {
+            throw new DuplicatePreReservationException("중복된 사전 예약이 이미 존재합니다.");
         }
-
         PreReservation preReservation = new PreReservation(command.getName(), command.getPhoneNumber());
         savePreReservationPort.save(preReservation);
+    }
+
+    private boolean checkDuplicate(String name, String phoneNumber) {
+        return savePreReservationPort.existsByNameAndPhoneNumber(name, phoneNumber);
     }
 }

--- a/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
@@ -20,10 +20,10 @@ public class PreReservationService implements CreatePreReservationUseCase {
     @Transactional
     @Override
     public void createPreReservation(PreReservationCommand command) {
-        if (checkDuplicate(command.getName(), command.getPhoneNumber())) {
+        if (checkDuplicate(command.name(), command.phoneNumber())) {
             throw new DuplicatePreReservationException("중복된 사전 예약이 이미 존재합니다.");
         }
-        PreReservation preReservation = new PreReservation(command.getName(), command.getPhoneNumber());
+        PreReservation preReservation = new PreReservation(command.name(), command.phoneNumber());
         savePreReservationPort.save(preReservation);
     }
 

--- a/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
@@ -1,0 +1,29 @@
+package co.yapp.orbit.prereservation.application;
+
+import co.yapp.orbit.prereservation.application.port.in.CreatePreReservationUseCase;
+import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
+import co.yapp.orbit.prereservation.application.port.out.SavePreReservationPort;
+import co.yapp.orbit.prereservation.domain.PreReservation;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PreReservationService implements CreatePreReservationUseCase {
+
+    private final SavePreReservationPort savePreReservationPort;
+
+    public PreReservationService(SavePreReservationPort savePreReservationPort) {
+        this.savePreReservationPort = savePreReservationPort;
+    }
+
+    @Transactional
+    @Override
+    public void createPreReservation(PreReservationCommand command) {
+        if (savePreReservationPort.existsByNameAndPhoneNumber(command.getName(), command.getPhoneNumber())) {
+            throw new IllegalArgumentException("이미 동일한 이름과 전화번호로 사전예약이 존재합니다.");
+        }
+
+        PreReservation preReservation = new PreReservation(command.getName(), command.getPhoneNumber());
+        savePreReservationPort.save(preReservation);
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/application/exception/DuplicatePreReservationException.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/exception/DuplicatePreReservationException.java
@@ -1,0 +1,7 @@
+package co.yapp.orbit.prereservation.application.exception;
+
+public class DuplicatePreReservationException extends RuntimeException {
+    public DuplicatePreReservationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/application/exception/InvalidPreReservationCommandException.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/exception/InvalidPreReservationCommandException.java
@@ -1,0 +1,7 @@
+package co.yapp.orbit.prereservation.application.exception;
+
+public class InvalidPreReservationCommandException extends RuntimeException {
+    public InvalidPreReservationCommandException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/application/port/in/CreatePreReservationUseCase.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/port/in/CreatePreReservationUseCase.java
@@ -1,0 +1,5 @@
+package co.yapp.orbit.prereservation.application.port.in;
+
+public interface CreatePreReservationUseCase {
+    void createPreReservation(PreReservationCommand command);
+}

--- a/src/main/java/co/yapp/orbit/prereservation/application/port/in/PreReservationCommand.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/port/in/PreReservationCommand.java
@@ -1,0 +1,17 @@
+package co.yapp.orbit.prereservation.application.port.in;
+
+import lombok.Getter;
+
+@Getter
+public class PreReservationCommand {
+    private String name;
+    private String phoneNumber;
+
+    public PreReservationCommand() {
+    }
+
+    public PreReservationCommand(String name, String phoneNumber) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/application/port/in/PreReservationCommand.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/port/in/PreReservationCommand.java
@@ -1,22 +1,14 @@
 package co.yapp.orbit.prereservation.application.port.in;
 
 import co.yapp.orbit.prereservation.application.exception.InvalidPreReservationCommandException;
-import lombok.Getter;
 
-@Getter
-public class PreReservationCommand {
-    private final String name;
-    private final String phoneNumber;
-
-    public PreReservationCommand(String name, String phoneNumber) {
+public record PreReservationCommand(String name, String phoneNumber) {
+    public PreReservationCommand {
         if (name == null || name.trim().isEmpty()) {
             throw new InvalidPreReservationCommandException("이름(name)는 null 또는 빈 값일 수 없습니다.");
         }
         if (phoneNumber == null || phoneNumber.trim().isEmpty()) {
             throw new InvalidPreReservationCommandException("전화번호(phoneNumber)는 null 또는 빈 값일 수 없습니다.");
         }
-        this.name = name;
-        this.phoneNumber = phoneNumber;
-
     }
 }

--- a/src/main/java/co/yapp/orbit/prereservation/application/port/in/PreReservationCommand.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/port/in/PreReservationCommand.java
@@ -1,17 +1,22 @@
 package co.yapp.orbit.prereservation.application.port.in;
 
+import co.yapp.orbit.prereservation.application.exception.InvalidPreReservationCommandException;
 import lombok.Getter;
 
 @Getter
 public class PreReservationCommand {
-    private String name;
-    private String phoneNumber;
-
-    public PreReservationCommand() {
-    }
+    private final String name;
+    private final String phoneNumber;
 
     public PreReservationCommand(String name, String phoneNumber) {
+        if (name == null || name.trim().isEmpty()) {
+            throw new InvalidPreReservationCommandException("이름(name)는 null 또는 빈 값일 수 없습니다.");
+        }
+        if (phoneNumber == null || phoneNumber.trim().isEmpty()) {
+            throw new InvalidPreReservationCommandException("전화번호(phoneNumber)는 null 또는 빈 값일 수 없습니다.");
+        }
         this.name = name;
         this.phoneNumber = phoneNumber;
+
     }
 }

--- a/src/main/java/co/yapp/orbit/prereservation/application/port/out/SavePreReservationPort.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/port/out/SavePreReservationPort.java
@@ -1,0 +1,8 @@
+package co.yapp.orbit.prereservation.application.port.out;
+
+import co.yapp.orbit.prereservation.domain.PreReservation;
+
+public interface SavePreReservationPort {
+    boolean existsByNameAndPhoneNumber(String name, String phoneNumber);
+    void save(PreReservation preReservation);
+}

--- a/src/main/java/co/yapp/orbit/prereservation/domain/PreReservation.java
+++ b/src/main/java/co/yapp/orbit/prereservation/domain/PreReservation.java
@@ -1,0 +1,29 @@
+package co.yapp.orbit.prereservation.domain;
+
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
+public class PreReservation {
+
+    private final String name;
+    private final String phoneNumber;
+
+    public PreReservation(String name, String phoneNumber) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PreReservation that)) return false;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(phoneNumber, that.phoneNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, phoneNumber);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,6 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
+    open-in-view: false
     show-sql: true
     generate-ddl: true
     hibernate:
@@ -13,4 +14,3 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    database-platform: org.hibernate.dialect.MySQLDialect

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,6 +6,7 @@ spring:
     driver-class-name: org.h2.Driver
 
   jpa:
+    open-in-view: false
     show-sql: true
     generate-ddl: true
     hibernate:
@@ -13,7 +14,6 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
 
   h2:
     console:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,6 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
+    open-in-view: false
     show-sql: true
     generate-ddl: true
     hibernate:
@@ -13,5 +14,3 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    database-platform: org.hibernate.dialect.MySQLDialect
-

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/in/PreReservationControllerTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/in/PreReservationControllerTest.java
@@ -1,26 +1,35 @@
 package co.yapp.orbit.prereservation.adapter.in;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import co.yapp.orbit.prereservation.adapter.in.request.PreReservationCreateRequest;
+import co.yapp.orbit.prereservation.application.exception.DuplicatePreReservationException;
+import co.yapp.orbit.prereservation.application.exception.InvalidPreReservationCommandException;
 import co.yapp.orbit.prereservation.application.port.in.CreatePreReservationUseCase;
 import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.beans.factory.annotation.Autowired;
 
-
 @WebMvcTest(controllers = PreReservationController.class)
+@AutoConfigureWebMvc
 class PreReservationControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockitoBean
     private CreatePreReservationUseCase createPreReservationUseCase;
@@ -41,10 +50,36 @@ class PreReservationControllerTest {
     }
 
     @Test
+    @DisplayName("이름이 null이면 400 Bad Request")
+    void createPreReservation_nullName() throws Exception {
+        PreReservationCreateRequest req = new PreReservationCreateRequest(null, "010-1234-5678");
+
+        mockMvc.perform(
+                post("/api/v1/prereservations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("전화번호가 빈문자면 400 Bad Request")
+    void createPreReservation_emptyPhoneNumber() throws Exception {
+        PreReservationCreateRequest req = new PreReservationCreateRequest("홍길동", "");
+
+        mockMvc.perform(
+                post("/api/v1/prereservations")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(req))
+            )
+            .andExpect(result -> assertTrue(result.getResolvedException() instanceof InvalidPreReservationCommandException));
+    }
+
+    @Test
     @DisplayName("이미 존재할 경우 409 CONFLICT 응답을 반환한다.")
     void createPreReservation_whenDuplicate_shouldReturn409() throws Exception {
         // given
-        Mockito.doThrow(new IllegalArgumentException("이미 동일한 이름과 전화번호로 사전예약이 존재합니다."))
+        Mockito.doThrow(new DuplicatePreReservationException("이미 동일한 이름과 전화번호로 사전예약이 존재합니다."))
             .when(createPreReservationUseCase)
             .createPreReservation(any(PreReservationCommand.class));
 
@@ -52,7 +87,6 @@ class PreReservationControllerTest {
         mockMvc.perform(post("/api/v1/prereservations")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"name\": \"홍길동\", \"phoneNumber\": \"010-1234-5678\"}"))
-            .andExpect(status().isConflict())
-            .andExpect(content().string("이미 동일한 이름과 전화번호로 사전예약이 존재합니다."));
+            .andExpect(status().isConflict());
     }
 }

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/in/PreReservationControllerTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/in/PreReservationControllerTest.java
@@ -1,0 +1,58 @@
+package co.yapp.orbit.prereservation.adapter.in;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import co.yapp.orbit.prereservation.application.port.in.CreatePreReservationUseCase;
+import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+
+@WebMvcTest(controllers = PreReservationController.class)
+class PreReservationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CreatePreReservationUseCase createPreReservationUseCase;
+
+    @Test
+    @DisplayName("새로운 사전 예약 생성시 200 OK 응답을 반환한다.")
+    void createPreReservation_shouldReturnOk() throws Exception {
+        // given
+        // Service 레이어가 정상 동작한다고 가정
+        Mockito.doNothing().when(createPreReservationUseCase).createPreReservation(any(
+            PreReservationCommand.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/prereservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\": \"홍길동\", \"phoneNumber\": \"010-1234-5678\"}"))
+            .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("이미 존재할 경우 409 CONFLICT 응답을 반환한다.")
+    void createPreReservation_whenDuplicate_shouldReturn409() throws Exception {
+        // given
+        Mockito.doThrow(new IllegalArgumentException("이미 동일한 이름과 전화번호로 사전예약이 존재합니다."))
+            .when(createPreReservationUseCase)
+            .createPreReservation(any(PreReservationCommand.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/prereservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"name\": \"홍길동\", \"phoneNumber\": \"010-1234-5678\"}"))
+            .andExpect(status().isConflict())
+            .andExpect(content().string("이미 동일한 이름과 전화번호로 사전예약이 존재합니다."));
+    }
+}

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapterTest.java
@@ -1,0 +1,69 @@
+package co.yapp.orbit.prereservation.adapter.out;
+
+import co.yapp.orbit.prereservation.domain.PreReservation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PreReservationPersistenceAdapterTest {
+
+    @Autowired
+    private PreReservationRepository preReservationRepository;
+
+    @Autowired
+    private PreReservationPersistenceAdapter preReservationPersistenceAdapter;
+
+    @BeforeEach
+    void setUp() {
+        preReservationRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("중복 존재 체크 - 존재하지 않으면 false 리턴")
+    void existsByNameAndPhoneNumber_whenNotExist_returnFalse() {
+        // given
+        String name = "홍길동";
+        String phone = "010-1234-5678";
+
+        // when
+        boolean result = preReservationPersistenceAdapter.existsByNameAndPhoneNumber(name, phone);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("중복 존재 체크 - 존재하면 true 리턴")
+    void existsByNameAndPhoneNumber_whenExist_returnTrue() {
+        // given
+        String name = "홍길동";
+        String phone = "010-1234-5678";
+        PreReservationEntity entity = new PreReservationEntity(name, phone);
+        preReservationRepository.save(entity);
+
+        // when
+        boolean result = preReservationPersistenceAdapter.existsByNameAndPhoneNumber(name, phone);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("PreReservation 도메인 객체를 DB에 정상적으로 저장")
+    void save() {
+        // given
+        PreReservation domain = new PreReservation("홍길동", "010-1234-5678");
+
+        // when
+        preReservationPersistenceAdapter.save(domain);
+
+        // then
+        boolean exists = preReservationRepository.existsByNameAndPhoneNumber("홍길동", "010-1234-5678");
+        assertThat(exists).isTrue();
+    }
+}

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationRepositoryTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationRepositoryTest.java
@@ -1,0 +1,29 @@
+package co.yapp.orbit.prereservation.adapter.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class PreReservationRepositoryTest {
+
+    @Autowired
+    private PreReservationRepository preReservationRepository;
+
+    @Test
+    @DisplayName("existsByNameAndPhoneNumber 정상 동작 테스트")
+    void testExistsByNameAndPhoneNumber() {
+        // given
+        PreReservationEntity entity = new PreReservationEntity("홍길동", "010-1234-5678");
+        preReservationRepository.save(entity);
+
+        // when
+        boolean exists = preReservationRepository.existsByNameAndPhoneNumber("홍길동", "010-1234-5678");
+
+        // then
+        assertThat(exists).isTrue();
+    }
+}

--- a/src/test/java/co/yapp/orbit/prereservation/application/PreReservationServiceTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/application/PreReservationServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import co.yapp.orbit.prereservation.application.exception.DuplicatePreReservationException;
 import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
 import co.yapp.orbit.prereservation.application.port.out.SavePreReservationPort;
 import co.yapp.orbit.prereservation.domain.PreReservation;
@@ -52,7 +53,7 @@ class PreReservationServiceTest {
             .thenReturn(true);
 
         // when & then
-        assertThrows(IllegalArgumentException.class, () ->
+        assertThrows(DuplicatePreReservationException.class, () ->
             preReservationService.createPreReservation(command)
         );
 

--- a/src/test/java/co/yapp/orbit/prereservation/application/PreReservationServiceTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/application/PreReservationServiceTest.java
@@ -1,0 +1,61 @@
+package co.yapp.orbit.prereservation.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
+import co.yapp.orbit.prereservation.application.port.out.SavePreReservationPort;
+import co.yapp.orbit.prereservation.domain.PreReservation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class PreReservationServiceTest {
+
+    private PreReservationService preReservationService;
+    private SavePreReservationPort savePreReservationPort;
+
+    @BeforeEach
+    void setUp() {
+        savePreReservationPort = Mockito.mock(SavePreReservationPort.class);
+        preReservationService = new PreReservationService(savePreReservationPort);
+    }
+
+    @Test
+    @DisplayName("중복되지 않은 사전예약 요청이면 정상적으로 저장되어야 한다.")
+    void createPreReservation_whenNotExist_thenSave() {
+        // given
+        PreReservationCommand command = new PreReservationCommand("홍길동", "010-1234-5678");
+
+        when(savePreReservationPort.existsByNameAndPhoneNumber("홍길동", "010-1234-5678"))
+            .thenReturn(false);
+
+        // when
+        preReservationService.createPreReservation(command);
+
+        // then
+        verify(savePreReservationPort, times(1)).save(any(PreReservation.class));
+    }
+
+    @Test
+    @DisplayName("이미 동일 정보가 존재하면 예외 발생")
+    void createPreReservation_whenExist_thenThrowException() {
+        // given
+        PreReservationCommand command = new PreReservationCommand("홍길동", "010-1234-5678");
+
+        when(savePreReservationPort.existsByNameAndPhoneNumber("홍길동", "010-1234-5678"))
+            .thenReturn(true);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () ->
+            preReservationService.createPreReservation(command)
+        );
+
+        verify(savePreReservationPort, never()).save(any(PreReservation.class));
+    }
+}

--- a/src/test/java/co/yapp/orbit/prereservation/domain/PreReservationTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/domain/PreReservationTest.java
@@ -1,0 +1,63 @@
+package co.yapp.orbit.prereservation.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PreReservationTest {
+
+    @Test
+    @DisplayName("동일한 이름과 전화번호를 가진 객체는 equals()가 true를 반환해야 한다.")
+    void equals_sameNameAndPhoneNumber_returnsTrue() {
+        // given
+        PreReservation preReservation1 = new PreReservation("홍길동", "010-1234-5678");
+        PreReservation preReservation2 = new PreReservation("홍길동", "010-1234-5678");
+
+        // when & then
+        assertThat(preReservation1).hasSameHashCodeAs(preReservation2);
+    }
+
+    @Test
+    @DisplayName("이름이 다르면 equals()가 false를 반환해야 한다.")
+    void equals_differentName_returnsFalse() {
+        // given
+        PreReservation preReservation1 = new PreReservation("홍길동", "010-1234-5678");
+        PreReservation preReservation2 = new PreReservation("이순신", "010-1234-5678");
+
+        // when & then
+        assertThat(preReservation1).isNotEqualTo(preReservation2);
+    }
+
+    @Test
+    @DisplayName("전화번호가 다르면 equals()가 false를 반환해야 한다.")
+    void equals_differentPhoneNumber_returnsFalse() {
+        // given
+        PreReservation preReservation1 = new PreReservation("홍길동", "010-1234-5678");
+        PreReservation preReservation2 = new PreReservation("홍길동", "010-9876-5432");
+
+        // when & then
+        assertThat(preReservation1).isNotEqualTo(preReservation2);
+    }
+
+    @Test
+    @DisplayName("자기 자신과는 equals()가 true여야 한다.")
+    void equals_itself_returnsTrue() {
+        // given
+        PreReservation preReservation = new PreReservation("홍길동", "010-1234-5678");
+
+        // when & then
+        assertThat(preReservation).isEqualTo(preReservation);
+    }
+
+    @Test
+    @DisplayName("다른 타입의 객체와는 equals()가 false여야 한다.")
+    void equals_differentType_returnsFalse() {
+        // given
+        PreReservation preReservation = new PreReservation("홍길동", "010-1234-5678");
+        String otherObject = "홍길동";
+
+        // when & then
+        assertThat(preReservation).isNotEqualTo(otherObject);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
[//]:
closed #<issue_number>

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [x] 🔨 Refactor Code refactoring
- [x] ⚙️ Setting Development environment setup
- [x] ✅ Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 사전 예약 API를 도메인, 퍼시스턴스, 테스트 계층과 함께 추가하였습니다.
  - 도메인 모델과 해당 JPA 엔티티를 정의
  - 사전 예약 생성 요청을 처리하는 REST 컨트롤러를 도입
- 중복 체크 및 신규 사전 예약 저장을 포함한 유즈케이스 로직을 구현하였습니다.
- `ExceptionHandler` 구현 및 SLF4J를 통한 로깅을 추가하였습니다.
- YAML 설정을 업데이트하여 개발, 로컬, 운영 환경에서 `spring.jpa.open-in-view`를 false로 설정 및 Hibernate dialect 설정을 제거하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] Task1

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)