### PR TITLE
[YAF-103] Replace Name with Email in PreReservation API

### DIFF
--- a/src/main/java/co/yapp/orbit/prereservation/adapter/in/PreReservationController.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/in/PreReservationController.java
@@ -22,7 +22,7 @@ public class PreReservationController {
     @PostMapping
     public ResponseEntity<?> createPreReservation(@RequestBody PreReservationCreateRequest request) {
         PreReservationCommand command = new PreReservationCommand(
-            request.getName(),
+            request.getEmail(),
             request.getPhoneNumber()
         );
         createPreReservationUseCase.createPreReservation(command);

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/in/request/PreReservationCreateRequest.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/in/request/PreReservationCreateRequest.java
@@ -7,12 +7,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class PreReservationCreateRequest {
 
-    private String name;
+    private String email;
 
     private String phoneNumber;
 
-    public PreReservationCreateRequest(String name, String phoneNumber) {
-        this.name = name;
+    public PreReservationCreateRequest(String email, String phoneNumber) {
+        this.email = email;
         this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationEntity.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationEntity.java
@@ -16,15 +16,15 @@ public class PreReservationEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    private String email;
 
     private String phoneNumber;
 
     protected PreReservationEntity() {
     }
 
-    public PreReservationEntity(String name, String phoneNumber) {
-        this.name = name;
+    public PreReservationEntity(String email, String phoneNumber) {
+        this.email = email;
         this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapter.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapter.java
@@ -14,14 +14,14 @@ public class PreReservationPersistenceAdapter implements SavePreReservationPort 
     }
 
     @Override
-    public boolean existsByNameAndPhoneNumber(String name, String phoneNumber) {
-        return preReservationRepository.existsByNameAndPhoneNumber(name, phoneNumber);
+    public boolean existsByEmailAndPhoneNumber(String email, String phoneNumber) {
+        return preReservationRepository.existsByEmailAndPhoneNumber(email, phoneNumber);
     }
 
     @Override
     public void save(PreReservation preReservation) {
         PreReservationEntity entity = new PreReservationEntity(
-            preReservation.getName(),
+            preReservation.getEmail(),
             preReservation.getPhoneNumber()
         );
         preReservationRepository.save(entity);

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationRepository.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationRepository.java
@@ -3,5 +3,5 @@ package co.yapp.orbit.prereservation.adapter.out;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PreReservationRepository extends JpaRepository<PreReservationEntity, Long> {
-    boolean existsByNameAndPhoneNumber(String name, String phoneNumber);
+    boolean existsByEmailAndPhoneNumber(String email, String phoneNumber);
 }

--- a/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
@@ -20,14 +20,14 @@ public class PreReservationService implements CreatePreReservationUseCase {
     @Transactional
     @Override
     public void createPreReservation(PreReservationCommand command) {
-        if (checkDuplicate(command.name(), command.phoneNumber())) {
+        if (checkDuplicate(command.email(), command.phoneNumber())) {
             throw new DuplicatePreReservationException("중복된 사전 예약이 이미 존재합니다.");
         }
-        PreReservation preReservation = new PreReservation(command.name(), command.phoneNumber());
+        PreReservation preReservation = new PreReservation(command.email(), command.phoneNumber());
         savePreReservationPort.save(preReservation);
     }
 
-    private boolean checkDuplicate(String name, String phoneNumber) {
-        return savePreReservationPort.existsByNameAndPhoneNumber(name, phoneNumber);
+    private boolean checkDuplicate(String email, String phoneNumber) {
+        return savePreReservationPort.existsByEmailAndPhoneNumber(email, phoneNumber);
     }
 }

--- a/src/main/java/co/yapp/orbit/prereservation/application/port/in/PreReservationCommand.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/port/in/PreReservationCommand.java
@@ -2,10 +2,10 @@ package co.yapp.orbit.prereservation.application.port.in;
 
 import co.yapp.orbit.prereservation.application.exception.InvalidPreReservationCommandException;
 
-public record PreReservationCommand(String name, String phoneNumber) {
+public record PreReservationCommand(String email, String phoneNumber) {
     public PreReservationCommand {
-        if (name == null || name.trim().isEmpty()) {
-            throw new InvalidPreReservationCommandException("이름(name)는 null 또는 빈 값일 수 없습니다.");
+        if (email == null || email.trim().isEmpty()) {
+            throw new InvalidPreReservationCommandException("이메일(email)는 null 또는 빈 값일 수 없습니다.");
         }
         if (phoneNumber == null || phoneNumber.trim().isEmpty()) {
             throw new InvalidPreReservationCommandException("전화번호(phoneNumber)는 null 또는 빈 값일 수 없습니다.");

--- a/src/main/java/co/yapp/orbit/prereservation/application/port/out/SavePreReservationPort.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/port/out/SavePreReservationPort.java
@@ -3,6 +3,6 @@ package co.yapp.orbit.prereservation.application.port.out;
 import co.yapp.orbit.prereservation.domain.PreReservation;
 
 public interface SavePreReservationPort {
-    boolean existsByNameAndPhoneNumber(String name, String phoneNumber);
+    boolean existsByEmailAndPhoneNumber(String email, String phoneNumber);
     void save(PreReservation preReservation);
 }

--- a/src/main/java/co/yapp/orbit/prereservation/domain/PreReservation.java
+++ b/src/main/java/co/yapp/orbit/prereservation/domain/PreReservation.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 @Getter
 public class PreReservation {
 
-    private final String name;
+    private final String email;
     private final String phoneNumber;
 
-    public PreReservation(String name, String phoneNumber) {
-        this.name = name;
+    public PreReservation(String email, String phoneNumber) {
+        this.email = email;
         this.phoneNumber = phoneNumber;
     }
 
@@ -18,12 +18,12 @@ public class PreReservation {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof PreReservation that)) return false;
-        return Objects.equals(name, that.name) &&
+        return Objects.equals(email, that.email) &&
             Objects.equals(phoneNumber, that.phoneNumber);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, phoneNumber);
+        return Objects.hash(email, phoneNumber);
     }
 }

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/in/PreReservationControllerTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/in/PreReservationControllerTest.java
@@ -45,12 +45,12 @@ class PreReservationControllerTest {
         // when & then
         mockMvc.perform(post("/api/v1/prereservations")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\": \"홍길동\", \"phoneNumber\": \"010-1234-5678\"}"))
+                .content("{\"email\": \"byungwook-min@naver.com\", \"phoneNumber\": \"010-1234-5678\"}"))
             .andExpect(status().isOk());
     }
 
     @Test
-    @DisplayName("이름이 null이면 400 Bad Request")
+    @DisplayName("이메일이 null이면 400 Bad Request")
     void createPreReservation_nullName() throws Exception {
         PreReservationCreateRequest req = new PreReservationCreateRequest(null, "010-1234-5678");
 
@@ -79,14 +79,14 @@ class PreReservationControllerTest {
     @DisplayName("이미 존재할 경우 409 CONFLICT 응답을 반환한다.")
     void createPreReservation_whenDuplicate_shouldReturn409() throws Exception {
         // given
-        Mockito.doThrow(new DuplicatePreReservationException("이미 동일한 이름과 전화번호로 사전예약이 존재합니다."))
+        Mockito.doThrow(new DuplicatePreReservationException("이미 동일한 이메일과 전화번호로 사전예약이 존재합니다."))
             .when(createPreReservationUseCase)
             .createPreReservation(any(PreReservationCommand.class));
 
         // when & then
         mockMvc.perform(post("/api/v1/prereservations")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("{\"name\": \"홍길동\", \"phoneNumber\": \"010-1234-5678\"}"))
+                .content("{\"email\": \"byungwook-min@naver.com\", \"phoneNumber\": \"010-1234-5678\"}"))
             .andExpect(status().isConflict());
     }
 }

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapterTest.java
@@ -25,13 +25,13 @@ class PreReservationPersistenceAdapterTest {
 
     @Test
     @DisplayName("중복 존재 체크 - 존재하지 않으면 false 리턴")
-    void existsByNameAndPhoneNumber_whenNotExist_returnFalse() {
+    void existsByEmailAndPhoneNumber_whenNotExist_returnFalse() {
         // given
-        String name = "홍길동";
+        String email = "byungwook-min@naver.com";
         String phone = "010-1234-5678";
 
         // when
-        boolean result = preReservationPersistenceAdapter.existsByNameAndPhoneNumber(name, phone);
+        boolean result = preReservationPersistenceAdapter.existsByEmailAndPhoneNumber(email, phone);
 
         // then
         assertThat(result).isFalse();
@@ -39,15 +39,15 @@ class PreReservationPersistenceAdapterTest {
 
     @Test
     @DisplayName("중복 존재 체크 - 존재하면 true 리턴")
-    void existsByNameAndPhoneNumber_whenExist_returnTrue() {
+    void existsByEmailAndPhoneNumber_whenExist_returnTrue() {
         // given
-        String name = "홍길동";
+        String email = "byungwook-min@naver.com";
         String phone = "010-1234-5678";
-        PreReservationEntity entity = new PreReservationEntity(name, phone);
+        PreReservationEntity entity = new PreReservationEntity(email, phone);
         preReservationRepository.save(entity);
 
         // when
-        boolean result = preReservationPersistenceAdapter.existsByNameAndPhoneNumber(name, phone);
+        boolean result = preReservationPersistenceAdapter.existsByEmailAndPhoneNumber(email, phone);
 
         // then
         assertThat(result).isTrue();
@@ -63,7 +63,7 @@ class PreReservationPersistenceAdapterTest {
         preReservationPersistenceAdapter.save(domain);
 
         // then
-        boolean exists = preReservationRepository.existsByNameAndPhoneNumber("홍길동", "010-1234-5678");
+        boolean exists = preReservationRepository.existsByEmailAndPhoneNumber("홍길동", "010-1234-5678");
         assertThat(exists).isTrue();
     }
 }

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationRepositoryTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationRepositoryTest.java
@@ -21,7 +21,7 @@ class PreReservationRepositoryTest {
         preReservationRepository.save(entity);
 
         // when
-        boolean exists = preReservationRepository.existsByNameAndPhoneNumber("홍길동", "010-1234-5678");
+        boolean exists = preReservationRepository.existsByEmailAndPhoneNumber("홍길동", "010-1234-5678");
 
         // then
         assertThat(exists).isTrue();

--- a/src/test/java/co/yapp/orbit/prereservation/application/PreReservationServiceTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/application/PreReservationServiceTest.java
@@ -33,7 +33,7 @@ class PreReservationServiceTest {
         // given
         PreReservationCommand command = new PreReservationCommand("홍길동", "010-1234-5678");
 
-        when(savePreReservationPort.existsByNameAndPhoneNumber("홍길동", "010-1234-5678"))
+        when(savePreReservationPort.existsByEmailAndPhoneNumber("홍길동", "010-1234-5678"))
             .thenReturn(false);
 
         // when
@@ -49,7 +49,7 @@ class PreReservationServiceTest {
         // given
         PreReservationCommand command = new PreReservationCommand("홍길동", "010-1234-5678");
 
-        when(savePreReservationPort.existsByNameAndPhoneNumber("홍길동", "010-1234-5678"))
+        when(savePreReservationPort.existsByEmailAndPhoneNumber("홍길동", "010-1234-5678"))
             .thenReturn(true);
 
         // when & then

--- a/src/test/java/co/yapp/orbit/prereservation/domain/PreReservationTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/domain/PreReservationTest.java
@@ -9,21 +9,21 @@ class PreReservationTest {
 
     @Test
     @DisplayName("동일한 이름과 전화번호를 가진 객체는 equals()가 true를 반환해야 한다.")
-    void equals_sameNameAndPhoneNumber_returnsTrue() {
+    void equals_sameEmailAndPhoneNumber_returnsTrue() {
         // given
-        PreReservation preReservation1 = new PreReservation("홍길동", "010-1234-5678");
-        PreReservation preReservation2 = new PreReservation("홍길동", "010-1234-5678");
+        PreReservation preReservation1 = new PreReservation("byungwook-min@naver.com", "010-1234-5678");
+        PreReservation preReservation2 = new PreReservation("byungwook-min@naver.com", "010-1234-5678");
 
         // when & then
         assertThat(preReservation1).hasSameHashCodeAs(preReservation2);
     }
 
     @Test
-    @DisplayName("이름이 다르면 equals()가 false를 반환해야 한다.")
+    @DisplayName("이메일이 다르면 equals()가 false를 반환해야 한다.")
     void equals_differentName_returnsFalse() {
         // given
-        PreReservation preReservation1 = new PreReservation("홍길동", "010-1234-5678");
-        PreReservation preReservation2 = new PreReservation("이순신", "010-1234-5678");
+        PreReservation preReservation1 = new PreReservation("byungwook-min@naver.com", "010-1234-5678");
+        PreReservation preReservation2 = new PreReservation("byungwook.min@yanolja.com", "010-1234-5678");
 
         // when & then
         assertThat(preReservation1).isNotEqualTo(preReservation2);
@@ -33,8 +33,8 @@ class PreReservationTest {
     @DisplayName("전화번호가 다르면 equals()가 false를 반환해야 한다.")
     void equals_differentPhoneNumber_returnsFalse() {
         // given
-        PreReservation preReservation1 = new PreReservation("홍길동", "010-1234-5678");
-        PreReservation preReservation2 = new PreReservation("홍길동", "010-9876-5432");
+        PreReservation preReservation1 = new PreReservation("byungwook-min@naver.com", "010-1234-5678");
+        PreReservation preReservation2 = new PreReservation("byungwook-min@naver.com", "010-9876-5432");
 
         // when & then
         assertThat(preReservation1).isNotEqualTo(preReservation2);
@@ -44,7 +44,7 @@ class PreReservationTest {
     @DisplayName("자기 자신과는 equals()가 true여야 한다.")
     void equals_itself_returnsTrue() {
         // given
-        PreReservation preReservation = new PreReservation("홍길동", "010-1234-5678");
+        PreReservation preReservation = new PreReservation("byungwook-min@naver.com", "010-1234-5678");
 
         // when & then
         assertThat(preReservation).isEqualTo(preReservation);
@@ -54,8 +54,8 @@ class PreReservationTest {
     @DisplayName("다른 타입의 객체와는 equals()가 false여야 한다.")
     void equals_differentType_returnsFalse() {
         // given
-        PreReservation preReservation = new PreReservation("홍길동", "010-1234-5678");
-        String otherObject = "홍길동";
+        PreReservation preReservation = new PreReservation("byungwook-min@naver.com", "010-1234-5678");
+        String otherObject = "byungwook-min@naver.com";
 
         // when & then
         assertThat(preReservation).isNotEqualTo(otherObject);


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #<issue_number>

어떤 변경사항이 있었나요?
- [x] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 기존에 pre-reservation API에서 사용하던 식별자(name)를 email로 변경하였습니다.
- 관련 도메인, Command, Persistence Layer, Repository 및 테스트 코드도 함께 수정하여, 중복 체크 기준을 email과 phoneNumber로 사용하도록 업데이트하였습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] Task1

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)