### PR TITLE
[YAF-110] Add Discord Webhook Notification for PreReservation Events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/out/DiscordWebhookAdapter.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/out/DiscordWebhookAdapter.java
@@ -1,0 +1,48 @@
+package co.yapp.orbit.prereservation.adapter.out;
+
+import co.yapp.orbit.prereservation.application.port.out.NotifyPreReservationPort;
+import co.yapp.orbit.prereservation.domain.PreReservation;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class DiscordWebhookAdapter implements NotifyPreReservationPort {
+
+    private final WebClient webClient;
+    private final String discordWebhookUrl;
+
+    public DiscordWebhookAdapter(
+        @Value("${discord.webhook.url}") String discordWebhookUrl
+    ) {
+        this.webClient = WebClient.create();
+        this.discordWebhookUrl = discordWebhookUrl;
+    }
+
+    @Override
+    public void notify(PreReservation preReservation) {
+        // 예시로 JSON 바디로 전달
+        String content = String.format("새로운 사전 예약이 등록되었습니다! 이메일: %s, 전화번호: %s",
+            preReservation.getEmail(), preReservation.getPhoneNumber());
+
+        webClient.post()
+            .uri(discordWebhookUrl)
+            .bodyValue(new DiscordWebhookRequest(content))
+            .retrieve()
+            .bodyToMono(Void.class)
+            .block();
+    }
+
+    @Setter
+    @Getter
+    static class DiscordWebhookRequest {
+        private String content;
+
+        public DiscordWebhookRequest(String content) {
+            this.content = content;
+        }
+
+    }
+}

--- a/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/PreReservationService.java
@@ -3,6 +3,7 @@ package co.yapp.orbit.prereservation.application;
 import co.yapp.orbit.prereservation.application.exception.DuplicatePreReservationException;
 import co.yapp.orbit.prereservation.application.port.in.CreatePreReservationUseCase;
 import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
+import co.yapp.orbit.prereservation.application.port.out.NotifyPreReservationPort;
 import co.yapp.orbit.prereservation.application.port.out.SavePreReservationPort;
 import co.yapp.orbit.prereservation.domain.PreReservation;
 import jakarta.transaction.Transactional;
@@ -12,9 +13,14 @@ import org.springframework.stereotype.Service;
 public class PreReservationService implements CreatePreReservationUseCase {
 
     private final SavePreReservationPort savePreReservationPort;
+    private final NotifyPreReservationPort notifyPreReservationPort; // 추가
 
-    public PreReservationService(SavePreReservationPort savePreReservationPort) {
+    public PreReservationService(
+        SavePreReservationPort savePreReservationPort,
+        NotifyPreReservationPort notifyPreReservationPort
+    ) {
         this.savePreReservationPort = savePreReservationPort;
+        this.notifyPreReservationPort = notifyPreReservationPort;
     }
 
     @Transactional
@@ -25,6 +31,8 @@ public class PreReservationService implements CreatePreReservationUseCase {
         }
         PreReservation preReservation = new PreReservation(command.email(), command.phoneNumber());
         savePreReservationPort.save(preReservation);
+
+        notifyPreReservationPort.notify(preReservation);
     }
 
     private boolean checkDuplicate(String email, String phoneNumber) {

--- a/src/main/java/co/yapp/orbit/prereservation/application/port/out/NotifyPreReservationPort.java
+++ b/src/main/java/co/yapp/orbit/prereservation/application/port/out/NotifyPreReservationPort.java
@@ -1,0 +1,7 @@
+package co.yapp.orbit.prereservation.application.port.out;
+
+import co.yapp.orbit.prereservation.domain.PreReservation;
+
+public interface NotifyPreReservationPort {
+    void notify(PreReservation preReservation);
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,3 +14,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+discord:
+  webhook:
+    url: {DISCORD_WEBHOOK_URL}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,3 +18,7 @@ spring:
   h2:
     console:
       enabled: true
+
+discord:
+  webhook:
+    url: {DISCORD_WEBHOOK_URL}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,3 +14,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+discord:
+  webhook:
+    url: {DISCORD_WEBHOOK_URL}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #<issue_number>

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- Add spring-boot-starter-webflux dependency to support WebClient.
- Create DiscordWebhookAdapter implementing NotifyPreReservationPort to send notifications via a Discord webhook.
- Introduce the NotifyPreReservationPort interface and update PreReservationService to trigger notifications after saving a pre-reservation.
- Add Discord webhook URL configuration placeholders in application-dev.yml, application-local.yml, and application-prod.yml.
- Update PreReservationServiceTest to verify notification behavior.


## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] Task1

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)