### PR TITLE
[YAF-87, YAF-89] Add SaveUser, LoadUser API with domain, persistence, and tests 

### DIFF
--- a/.github/workflows/pr-build-test.yml
+++ b/.github/workflows/pr-build-test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/src/main/java/co/yapp/orbit/global/config/BaseTimeConfig.java
+++ b/src/main/java/co/yapp/orbit/global/config/BaseTimeConfig.java
@@ -1,0 +1,16 @@
+package co.yapp.orbit.global.config;
+
+import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class BaseTimeConfig {
+
+    @PostConstruct
+    public void setSeoulTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/src/main/java/co/yapp/orbit/global/config/JpaAuditingConfig.java
+++ b/src/main/java/co/yapp/orbit/global/config/JpaAuditingConfig.java
@@ -1,9 +1,0 @@
-package co.yapp.orbit.global.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-
-@Configuration
-@EnableJpaAuditing
-public class JpaAuditingConfig {
-}

--- a/src/main/java/co/yapp/orbit/global/domain/BaseTimeEntity.java
+++ b/src/main/java/co/yapp/orbit/global/domain/BaseTimeEntity.java
@@ -1,0 +1,11 @@
+package co.yapp.orbit.global.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+}

--- a/src/main/java/co/yapp/orbit/global/domain/BaseTimeEntity.java
+++ b/src/main/java/co/yapp/orbit/global/domain/BaseTimeEntity.java
@@ -1,11 +1,21 @@
 package co.yapp.orbit.global.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationEntity.java
+++ b/src/main/java/co/yapp/orbit/prereservation/adapter/out/PreReservationEntity.java
@@ -1,5 +1,6 @@
 package co.yapp.orbit.prereservation.adapter.out;
 
+import co.yapp.orbit.global.domain.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -10,7 +11,7 @@ import lombok.Getter;
 @Getter
 @Entity
 @Table(name = "pre_reservation")
-public class PreReservationEntity {
+public class PreReservationEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
@@ -27,6 +27,7 @@ public class UserController {
             request.getName(),
             request.getBirthDate(),
             request.getBirthTime(),
+            request.getCalendarType(),
             request.getGender()
         );
         Long userId = createUserUseCase.saveUser(command);
@@ -41,6 +42,7 @@ public class UserController {
             user.getName(),
             user.getBirthDate().toString(),
             user.getBirthTime().toString(),
+            user.getCalendarType().toString(),
             user.getGender().name()
         );
         return ResponseEntity.ok(response);

--- a/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
@@ -1,8 +1,48 @@
 package co.yapp.orbit.user.adapter.in;
 
-import org.springframework.web.bind.annotation.RestController;
+import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
+import co.yapp.orbit.user.adapter.in.response.LoadUserResponse;
+import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
+import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
+import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.domain.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/api/v1/users")
 public class UserController {
 
+    private final SaveUserUseCase createUserUseCase;
+    private final LoadUserUseCase getUserUseCase;
+
+    public UserController(SaveUserUseCase createUserUseCase, LoadUserUseCase getUserUseCase) {
+        this.createUserUseCase = createUserUseCase;
+        this.getUserUseCase = getUserUseCase;
+    }
+
+    @PostMapping
+    public ResponseEntity<Long> createUser(@RequestBody SaveUserRequest request) {
+        UserCommand command = new UserCommand(
+            request.getName(),
+            request.getBirthDate(),
+            request.getBirthTime(),
+            request.getGender()
+        );
+        Long userId = createUserUseCase.saveUser(command);
+        return ResponseEntity.ok(userId);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<LoadUserResponse> getUser(@PathVariable("id") Long id) {
+        User user = getUserUseCase.loadUser(id);
+        LoadUserResponse response = new LoadUserResponse(
+            user.getId(),
+            user.getName(),
+            user.getBirthDate().toString(),
+            user.getBirthTime().toString(),
+            user.getGender().name()
+        );
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/in/exception/UserExceptionHandler.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/exception/UserExceptionHandler.java
@@ -1,0 +1,36 @@
+package co.yapp.orbit.user.adapter.in.exception;
+
+import co.yapp.orbit.user.application.exception.InvalidUserCommandException;
+import co.yapp.orbit.user.application.exception.UserNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "co.yapp.orbit.user.adapter.in")
+public class UserExceptionHandler {
+
+    @ExceptionHandler(InvalidUserCommandException.class)
+    public ResponseEntity<String> handleInvalidUserCommandException(InvalidUserCommandException e) {
+        log.error("InvalidUserCommandException: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(e.getMessage());
+    }
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException e) {
+        log.error("UserNotFoundException: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        log.error("Unhandled Exception: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(e.getMessage());
+    }
+
+}

--- a/src/main/java/co/yapp/orbit/user/adapter/in/request/SaveUserRequest.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/request/SaveUserRequest.java
@@ -1,0 +1,21 @@
+package co.yapp.orbit.user.adapter.in.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SaveUserRequest {
+
+    private String name;
+    private String birthDate;
+    private String birthTime;
+    private String gender;
+
+    public SaveUserRequest(String name, String birthDate, String birthTime, String gender) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.birthTime = birthTime;
+        this.gender = gender;
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/adapter/in/request/SaveUserRequest.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/request/SaveUserRequest.java
@@ -10,12 +10,14 @@ public class SaveUserRequest {
     private String name;
     private String birthDate;
     private String birthTime;
+    private String calendarType;
     private String gender;
 
-    public SaveUserRequest(String name, String birthDate, String birthTime, String gender) {
+    public SaveUserRequest(String name, String birthDate, String birthTime, String calendarType, String gender) {
         this.name = name;
         this.birthDate = birthDate;
         this.birthTime = birthTime;
+        this.calendarType = calendarType;
         this.gender = gender;
     }
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/in/response/LoadUserResponse.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/response/LoadUserResponse.java
@@ -11,13 +11,15 @@ public class LoadUserResponse {
     private String name;
     private String birthDate;
     private String birthTime;
+    private String calendarType;
     private String gender;
 
-    public LoadUserResponse(Long id, String name, String birthDate, String birthTime, String gender) {
+    public LoadUserResponse(Long id, String name, String birthDate, String birthTime, String calendarType, String gender) {
         this.id = id;
         this.name = name;
         this.birthDate = birthDate;
         this.birthTime = birthTime;
         this.gender = gender;
+        this.calendarType = calendarType;
     }
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/in/response/LoadUserResponse.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/response/LoadUserResponse.java
@@ -1,0 +1,23 @@
+package co.yapp.orbit.user.adapter.in.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoadUserResponse {
+
+    private Long id;
+    private String name;
+    private String birthDate;
+    private String birthTime;
+    private String gender;
+
+    public LoadUserResponse(Long id, String name, String birthDate, String birthTime, String gender) {
+        this.id = id;
+        this.name = name;
+        this.birthDate = birthDate;
+        this.birthTime = birthTime;
+        this.gender = gender;
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
@@ -1,11 +1,42 @@
 package co.yapp.orbit.user.adapter.out;
 
+import co.yapp.orbit.user.domain.Gender;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.Getter;
 
+@Getter
 @Entity
+@Table(name = "users")
 public class UserEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String name;
+
+    private LocalDate birthDate;
+
+    private LocalTime birthTime;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    protected UserEntity() {
+    }
+
+    public UserEntity(String name, LocalDate birthDate, LocalTime birthTime, Gender gender) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.birthTime = birthTime;
+        this.gender = gender;
+    }
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
@@ -1,6 +1,7 @@
 package co.yapp.orbit.user.adapter.out;
 
 import co.yapp.orbit.global.domain.BaseTimeEntity;
+import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -29,15 +30,19 @@ public class UserEntity extends BaseTimeEntity {
     private LocalTime birthTime;
 
     @Enumerated(EnumType.STRING)
+    private CalendarType calendarType;
+
+    @Enumerated(EnumType.STRING)
     private Gender gender;
 
     protected UserEntity() {
     }
 
-    public UserEntity(String name, LocalDate birthDate, LocalTime birthTime, Gender gender) {
+    public UserEntity(String name, LocalDate birthDate, LocalTime birthTime, CalendarType calendarType, Gender gender) {
         this.name = name;
         this.birthDate = birthDate;
         this.birthTime = birthTime;
+        this.calendarType = calendarType;
         this.gender = gender;
     }
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
@@ -1,5 +1,6 @@
 package co.yapp.orbit.user.adapter.out;
 
+import co.yapp.orbit.global.domain.BaseTimeEntity;
 import co.yapp.orbit.user.domain.Gender;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -14,8 +15,8 @@ import lombok.Getter;
 
 @Getter
 @Entity
-@Table(name = "users")
-public class UserEntity {
+@Table(name = "`user`")
+public class UserEntity extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapter.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapter.java
@@ -21,6 +21,7 @@ public class UserPersistenceAdapter implements SaveUserPort, LoadUserPort {
             user.getName(),
             user.getBirthDate(),
             user.getBirthTime(),
+            user.getCalendarType(),
             user.getGender()
         );
         UserEntity savedEntity = userRepository.save(entity);
@@ -35,6 +36,7 @@ public class UserPersistenceAdapter implements SaveUserPort, LoadUserPort {
                 entity.getName(),
                 entity.getBirthDate(),
                 entity.getBirthTime(),
+                entity.getCalendarType(),
                 entity.getGender()
             ));
     }

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapter.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapter.java
@@ -2,14 +2,40 @@ package co.yapp.orbit.user.adapter.out;
 
 import co.yapp.orbit.user.application.port.out.LoadUserPort;
 import co.yapp.orbit.user.application.port.out.SaveUserPort;
+import co.yapp.orbit.user.domain.User;
+import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UserPersistenceAdapter implements LoadUserPort, SaveUserPort {
+public class UserPersistenceAdapter implements SaveUserPort, LoadUserPort {
 
     private final UserRepository userRepository;
 
     public UserPersistenceAdapter(UserRepository userRepository) {
         this.userRepository = userRepository;
+    }
+
+    @Override
+    public Long save(User user) {
+        UserEntity entity = new UserEntity(
+            user.getName(),
+            user.getBirthDate(),
+            user.getBirthTime(),
+            user.getGender()
+        );
+        UserEntity savedEntity = userRepository.save(entity);
+        return savedEntity.getId();
+    }
+
+    @Override
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id)
+            .map(entity -> new User(
+                entity.getId(),
+                entity.getName(),
+                entity.getBirthDate(),
+                entity.getBirthTime(),
+                entity.getGender()
+            ));
     }
 }

--- a/src/main/java/co/yapp/orbit/user/application/LoadUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/LoadUserService.java
@@ -1,8 +1,11 @@
 package co.yapp.orbit.user.application;
 
+import co.yapp.orbit.user.application.exception.UserNotFoundException;
 import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
 import co.yapp.orbit.user.application.port.out.LoadUserPort;
+import co.yapp.orbit.user.domain.User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class LoadUserService implements LoadUserUseCase {
@@ -11,5 +14,12 @@ public class LoadUserService implements LoadUserUseCase {
 
     public LoadUserService(LoadUserPort loadUserPort) {
         this.loadUserPort = loadUserPort;
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public User loadUser(Long id) {
+        return loadUserPort.findById(id)
+            .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다. id: " + id));
     }
 }

--- a/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
@@ -3,6 +3,7 @@ package co.yapp.orbit.user.application;
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
 import co.yapp.orbit.user.application.port.in.UserCommand;
 import co.yapp.orbit.user.application.port.out.SaveUserPort;
+import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
 import java.time.LocalDate;
@@ -25,7 +26,8 @@ public class SaveUserService implements SaveUserUseCase {
         LocalDate birthDate = LocalDate.parse(command.birthDate());
         LocalTime birthTime = LocalTime.parse(command.birthTime());
         Gender gender = Gender.valueOf(command.gender().toUpperCase());
-        User user = new User(null, command.name(), birthDate, birthTime, gender);
+        CalendarType calendarType = CalendarType.valueOf(command.calendarType().toUpperCase());
+        User user = new User(null, command.name(), birthDate, birthTime, calendarType, gender);
         return saveUserPort.save(user);
     }
 }

--- a/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
@@ -1,8 +1,14 @@
 package co.yapp.orbit.user.application;
 
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
+import co.yapp.orbit.user.application.port.in.UserCommand;
 import co.yapp.orbit.user.application.port.out.SaveUserPort;
+import co.yapp.orbit.user.domain.Gender;
+import co.yapp.orbit.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class SaveUserService implements SaveUserUseCase {
@@ -11,5 +17,15 @@ public class SaveUserService implements SaveUserUseCase {
 
     public SaveUserService(SaveUserPort saveUserPort) {
         this.saveUserPort = saveUserPort;
+    }
+
+    @Transactional
+    @Override
+    public Long saveUser(UserCommand command) {
+        LocalDate birthDate = LocalDate.parse(command.birthDate());
+        LocalTime birthTime = LocalTime.parse(command.birthTime());
+        Gender gender = Gender.valueOf(command.gender().toUpperCase());
+        User user = new User(null, command.name(), birthDate, birthTime, gender);
+        return saveUserPort.save(user);
     }
 }

--- a/src/main/java/co/yapp/orbit/user/application/exception/InvalidUserCommandException.java
+++ b/src/main/java/co/yapp/orbit/user/application/exception/InvalidUserCommandException.java
@@ -1,0 +1,9 @@
+package co.yapp.orbit.user.application.exception;
+
+public class InvalidUserCommandException extends RuntimeException {
+
+    public InvalidUserCommandException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/co/yapp/orbit/user/application/exception/UserNotFoundException.java
+++ b/src/main/java/co/yapp/orbit/user/application/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package co.yapp.orbit.user.application.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/in/LoadUserUseCase.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/LoadUserUseCase.java
@@ -1,5 +1,8 @@
 package co.yapp.orbit.user.application.port.in;
 
+import co.yapp.orbit.user.domain.User;
+
 public interface LoadUserUseCase {
 
+    User loadUser(Long id);
 }

--- a/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserCommand.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserCommand.java
@@ -1,5 +1,0 @@
-package co.yapp.orbit.user.application.port.in;
-
-public class SaveUserCommand {
-
-}

--- a/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserUseCase.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserUseCase.java
@@ -2,4 +2,5 @@ package co.yapp.orbit.user.application.port.in;
 
 public interface SaveUserUseCase {
 
+    Long saveUser(UserCommand command);
 }

--- a/src/main/java/co/yapp/orbit/user/application/port/in/UserCommand.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/UserCommand.java
@@ -2,7 +2,7 @@ package co.yapp.orbit.user.application.port.in;
 
 import co.yapp.orbit.user.application.exception.InvalidUserCommandException;
 
-public record UserCommand(String name, String birthDate, String birthTime, String gender) {
+public record UserCommand(String name, String birthDate, String birthTime, String calendarType, String gender) {
     public UserCommand {
         if (name == null || name.trim().isEmpty()) {
             throw new InvalidUserCommandException("이름(name)은 null 또는 빈 값일 수 없습니다.");
@@ -10,8 +10,8 @@ public record UserCommand(String name, String birthDate, String birthTime, Strin
         if (birthDate == null || birthDate.trim().isEmpty()) {
             throw new InvalidUserCommandException("생년월일(birthDate)는 null 또는 빈 값일 수 없습니다.");
         }
-        if (birthTime == null || birthTime.trim().isEmpty()) {
-            throw new InvalidUserCommandException("태어난시간(birthTime)은 null 또는 빈 값일 수 없습니다.");
+        if (calendarType == null || calendarType.trim().isEmpty()) {
+            throw new InvalidUserCommandException("음력/양력(calendarType)는 null 또는 빈 값일 수 없습니다.");
         }
         if (gender == null || gender.trim().isEmpty()) {
             throw new InvalidUserCommandException("성별(gender)는 null 또는 빈 값일 수 없습니다.");

--- a/src/main/java/co/yapp/orbit/user/application/port/in/UserCommand.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/UserCommand.java
@@ -1,0 +1,20 @@
+package co.yapp.orbit.user.application.port.in;
+
+import co.yapp.orbit.user.application.exception.InvalidUserCommandException;
+
+public record UserCommand(String name, String birthDate, String birthTime, String gender) {
+    public UserCommand {
+        if (name == null || name.trim().isEmpty()) {
+            throw new InvalidUserCommandException("이름(name)은 null 또는 빈 값일 수 없습니다.");
+        }
+        if (birthDate == null || birthDate.trim().isEmpty()) {
+            throw new InvalidUserCommandException("생년월일(birthDate)는 null 또는 빈 값일 수 없습니다.");
+        }
+        if (birthTime == null || birthTime.trim().isEmpty()) {
+            throw new InvalidUserCommandException("태어난시간(birthTime)은 null 또는 빈 값일 수 없습니다.");
+        }
+        if (gender == null || gender.trim().isEmpty()) {
+            throw new InvalidUserCommandException("성별(gender)는 null 또는 빈 값일 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/out/LoadUserPort.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/out/LoadUserPort.java
@@ -1,4 +1,8 @@
 package co.yapp.orbit.user.application.port.out;
 
+import co.yapp.orbit.user.domain.User;
+import java.util.Optional;
+
 public interface LoadUserPort {
+    Optional<User> findById(Long id);
 }

--- a/src/main/java/co/yapp/orbit/user/application/port/out/SaveUserPort.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/out/SaveUserPort.java
@@ -1,5 +1,7 @@
 package co.yapp.orbit.user.application.port.out;
 
-public interface SaveUserPort {
+import co.yapp.orbit.user.domain.User;
 
+public interface SaveUserPort {
+    Long save(User user);
 }

--- a/src/main/java/co/yapp/orbit/user/domain/CalendarType.java
+++ b/src/main/java/co/yapp/orbit/user/domain/CalendarType.java
@@ -1,0 +1,6 @@
+package co.yapp.orbit.user.domain;
+
+public enum CalendarType {
+    SOLAR,
+    LUNAR
+}

--- a/src/main/java/co/yapp/orbit/user/domain/Gender.java
+++ b/src/main/java/co/yapp/orbit/user/domain/Gender.java
@@ -1,0 +1,7 @@
+package co.yapp.orbit.user.domain;
+
+public enum Gender {
+    MALE,
+    FEMALE,
+    OTHER
+}

--- a/src/main/java/co/yapp/orbit/user/domain/User.java
+++ b/src/main/java/co/yapp/orbit/user/domain/User.java
@@ -12,13 +12,15 @@ public class User {
     private final String name;
     private final LocalDate birthDate;
     private final LocalTime birthTime;
+    private final CalendarType calendarType;
     private final Gender gender;
 
-    public User(Long id, String name, LocalDate birthDate, LocalTime birthTime, Gender gender) {
+    public User(Long id, String name, LocalDate birthDate, LocalTime birthTime, CalendarType calendarType, Gender gender) {
         this.id = id;
         this.name = name;
         this.birthDate = birthDate;
         this.birthTime = birthTime;
+        this.calendarType = calendarType;
         this.gender = gender;
     }
 

--- a/src/main/java/co/yapp/orbit/user/domain/User.java
+++ b/src/main/java/co/yapp/orbit/user/domain/User.java
@@ -1,5 +1,42 @@
 package co.yapp.orbit.user.domain;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Objects;
+import lombok.Getter;
+
+@Getter
 public class User {
 
+    private final Long id;
+    private final String name;
+    private final LocalDate birthDate;
+    private final LocalTime birthTime;
+    private final Gender gender;
+
+    public User(Long id, String name, LocalDate birthDate, LocalTime birthTime, Gender gender) {
+        this.id = id;
+        this.name = name;
+        this.birthDate = birthDate;
+        this.birthTime = birthTime;
+        this.gender = gender;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof User user))
+            return false;
+        return Objects.equals(id, user.id)
+            && Objects.equals(name, user.name)
+            && Objects.equals(birthDate, user.birthDate)
+            && Objects.equals(birthTime, user.birthTime)
+            && gender == user.gender;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, birthDate, birthTime, gender);
+    }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,8 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
 
   h2:
     console:

--- a/src/test/java/co/yapp/orbit/OrbitApplicationTests.java
+++ b/src/test/java/co/yapp/orbit/OrbitApplicationTests.java
@@ -2,8 +2,10 @@ package co.yapp.orbit;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(properties = {"discord.webhook.url=http://dummy-url.com"})
+@ActiveProfiles("test")
+@SpringBootTest
 class OrbitApplicationTests {
 
 	@Test

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapterTest.java
@@ -57,13 +57,13 @@ class PreReservationPersistenceAdapterTest {
     @DisplayName("PreReservation 도메인 객체를 DB에 정상적으로 저장")
     void save() {
         // given
-        PreReservation domain = new PreReservation("홍길동", "010-1234-5678");
+        PreReservation domain = new PreReservation("byungwook-min@naver.com", "010-1234-5678");
 
         // when
         preReservationPersistenceAdapter.save(domain);
 
         // then
-        boolean exists = preReservationRepository.existsByEmailAndPhoneNumber("홍길동", "010-1234-5678");
+        boolean exists = preReservationRepository.existsByEmailAndPhoneNumber("byungwook-min@naver.com", "010-1234-5678");
         assertThat(exists).isTrue();
     }
 }

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/out/PreReservationPersistenceAdapterTest.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest(properties = {"discord.webhook.url=http://dummy-url.com"})
+@ActiveProfiles("test")
+@SpringBootTest
 class PreReservationPersistenceAdapterTest {
 
     @Autowired

--- a/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerTest.java
@@ -12,6 +12,7 @@ import co.yapp.orbit.user.application.exception.UserNotFoundException;
 import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
 import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,7 +50,8 @@ class UserControllerTest {
         Mockito.when(saveUserUseCase.saveUser(any(UserCommand.class)))
             .thenReturn(userId);
 
-        SaveUserRequest request = new SaveUserRequest("홍길동", "2025-02-09", "08:30:00", "MALE");
+        SaveUserRequest request = new SaveUserRequest("홍길동", "2025-02-09", "08:30:00", "SOLAR",
+            "MALE");
         String json = objectMapper.writeValueAsString(request);
 
         // when & then
@@ -63,7 +65,7 @@ class UserControllerTest {
     @Test
     @DisplayName("사용자 등록 시 이름이 null이면 400 Bad Request를 반환한다.")
     void saveUser_nullName_returnsBadRequest() throws Exception {
-        SaveUserRequest request = new SaveUserRequest(null, "2025-02-09", "08:30:00", "MALE");
+        SaveUserRequest request = new SaveUserRequest(null, "2025-02-09", "08:30:00", "SOLAR", "MALE");
         String json = objectMapper.writeValueAsString(request);
 
         mockMvc.perform(post("/api/v1/users")
@@ -75,7 +77,7 @@ class UserControllerTest {
     @Test
     @DisplayName("사용자 등록 시 생년월일이 빈 문자열이면 400 Bad Request를 반환한다.")
     void saveUser_emptyBirthDate_returnsBadRequest() throws Exception {
-        SaveUserRequest request = new SaveUserRequest("홍길동", "", "08:30:00", "MALE");
+        SaveUserRequest request = new SaveUserRequest("홍길동", "", "08:30:00", "SOLAR", "MALE");
         String json = objectMapper.writeValueAsString(request);
 
         mockMvc.perform(post("/api/v1/users")
@@ -87,7 +89,7 @@ class UserControllerTest {
     @Test
     @DisplayName("사용자 등록 시 유효하지 않은 성별이면 내부에서 예외가 발생하여 500 Internal Server Error를 반환한다.")
     void createUser_invalidGender_returnsInternalServerError() throws Exception {
-        SaveUserRequest request = new SaveUserRequest("홍길동", "2025-02-09", "08:30:00", "INVALID");
+        SaveUserRequest request = new SaveUserRequest("홍길동", "2025-02-09", "08:30:00", "SOLAR", "INVALID");
         String json = objectMapper.writeValueAsString(request);
 
         Mockito.doThrow(new IllegalArgumentException("No enum constant"))
@@ -119,6 +121,7 @@ class UserControllerTest {
             "홍길동",
             java.time.LocalDate.parse("2025-02-09"),
             java.time.LocalTime.parse("08:30:00"),
+            CalendarType.SOLAR,
             Gender.MALE
         );
         Mockito.when(getUserUseCase.loadUser(userId)).thenReturn(user);

--- a/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerTest.java
@@ -1,0 +1,134 @@
+package co.yapp.orbit.user.adapter.in;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
+import co.yapp.orbit.user.application.exception.UserNotFoundException;
+import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
+import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
+import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.domain.Gender;
+import co.yapp.orbit.user.domain.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = UserController.class)
+@AutoConfigureWebMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private SaveUserUseCase saveUserUseCase;
+
+    @MockitoBean
+    private LoadUserUseCase getUserUseCase;
+
+    @Test
+    @DisplayName("사용자 등록 성공 시 200 OK와 사용자 id를 반환한다.")
+    void saveUser_success() throws Exception {
+        // given
+        Long userId = 1L;
+        Mockito.when(saveUserUseCase.saveUser(any(UserCommand.class)))
+            .thenReturn(userId);
+
+        SaveUserRequest request = new SaveUserRequest("홍길동", "2025-02-09", "08:30:00", "MALE");
+        String json = objectMapper.writeValueAsString(request);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isOk())
+            .andExpect(content().string(String.valueOf(userId)));
+    }
+
+    @Test
+    @DisplayName("사용자 등록 시 이름이 null이면 400 Bad Request를 반환한다.")
+    void saveUser_nullName_returnsBadRequest() throws Exception {
+        SaveUserRequest request = new SaveUserRequest(null, "2025-02-09", "08:30:00", "MALE");
+        String json = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("사용자 등록 시 생년월일이 빈 문자열이면 400 Bad Request를 반환한다.")
+    void saveUser_emptyBirthDate_returnsBadRequest() throws Exception {
+        SaveUserRequest request = new SaveUserRequest("홍길동", "", "08:30:00", "MALE");
+        String json = objectMapper.writeValueAsString(request);
+
+        mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("사용자 등록 시 유효하지 않은 성별이면 내부에서 예외가 발생하여 500 Internal Server Error를 반환한다.")
+    void createUser_invalidGender_returnsInternalServerError() throws Exception {
+        SaveUserRequest request = new SaveUserRequest("홍길동", "2025-02-09", "08:30:00", "INVALID");
+        String json = objectMapper.writeValueAsString(request);
+
+        Mockito.doThrow(new IllegalArgumentException("No enum constant"))
+            .when(saveUserUseCase).saveUser(any(UserCommand.class));
+
+        mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("사용자 조회 시 존재하지 않으면 404 Not Found를 반환한다.")
+    void getUser_notFound_returnsNotFound() throws Exception {
+        Long userId = 1L;
+        Mockito.when(getUserUseCase.loadUser(userId))
+            .thenThrow(new UserNotFoundException("사용자를 찾을 수 없습니다. id: " + userId));
+
+        mockMvc.perform(get("/api/v1/users/{id}", userId))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("사용자 조회 시 정상적인 경우 200 OK와 사용자 정보를 반환한다.")
+    void getUser_success() throws Exception {
+        Long userId = 1L;
+        User user = new User(
+            userId,
+            "홍길동",
+            java.time.LocalDate.parse("2025-02-09"),
+            java.time.LocalTime.parse("08:30:00"),
+            Gender.MALE
+        );
+        Mockito.when(getUserUseCase.loadUser(userId)).thenReturn(user);
+
+        mockMvc.perform(get("/api/v1/users/{id}", userId))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(userId))
+            .andExpect(jsonPath("$.name").value("홍길동"))
+            .andExpect(jsonPath("$.birthDate").value("2025-02-09"))
+            .andExpect(jsonPath("$.birthTime").value("08:30"))
+            .andExpect(jsonPath("$.gender").value("MALE"));
+    }
+}

--- a/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
@@ -7,6 +7,7 @@ import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,26 +36,5 @@ class UserPersistenceAdapterTest {
         assertThat(userId).isNotNull();
         boolean exists = userRepository.findById(userId).isPresent();
         assertThat(exists).isTrue();
-    }
-
-    @Test
-    @DisplayName("UserPersistenceAdapter의 findById 메서드가 도메인 객체를 올바르게 반환한다.")
-    void findById() {
-        // given
-        UserEntity entity = new UserEntity("홍길동",
-        LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), CalendarType.SOLAR, Gender.MALE);
-        UserEntity savedEntity = userRepository.save(entity);
-        Long userId = savedEntity.getId();
-
-        // when
-        User user = userPersistenceAdapter.findById(userId).orElse(null);
-
-        // then
-        assertThat(user).isNotNull();
-        assertThat(user.getId()).isEqualTo(userId);
-        assertThat(user.getName()).isEqualTo("홍길동");
-        assertThat(user.getBirthDate()).isEqualTo(LocalDate.parse("2025-02-09"));
-        assertThat(user.getBirthTime()).isEqualTo(LocalTime.parse("08:30:00"));
-        assertThat(user.getGender()).isEqualTo(Gender.MALE);
     }
 }

--- a/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
@@ -2,6 +2,7 @@ package co.yapp.orbit.user.adapter.out;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
 import java.time.LocalDate;
@@ -29,7 +30,7 @@ class UserPersistenceAdapterTest {
     @Test
     @DisplayName("UserPersistenceAdapter의 save 메서드가 도메인 객체를 DB에 저장하고 id를 반환한다.")
     void save() {
-        User user = new User(null, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), Gender.MALE);
+        User user = new User(null, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), CalendarType.SOLAR, Gender.MALE);
         Long userId = userPersistenceAdapter.save(user);
         assertThat(userId).isNotNull();
         boolean exists = userRepository.findById(userId).isPresent();
@@ -41,7 +42,7 @@ class UserPersistenceAdapterTest {
     void findById() {
         // given
         UserEntity entity = new UserEntity("홍길동",
-            LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), Gender.MALE);
+        LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), CalendarType.SOLAR, Gender.MALE);
         UserEntity savedEntity = userRepository.save(entity);
         Long userId = savedEntity.getId();
 

--- a/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
@@ -7,14 +7,15 @@ import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.TimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(properties = {"discord.webhook.url=http://dummy-url.com"})
+@ActiveProfiles("test")
+@SpringBootTest
 class UserPersistenceAdapterTest {
 
     @Autowired

--- a/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
@@ -1,0 +1,59 @@
+package co.yapp.orbit.user.adapter.out;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.yapp.orbit.user.domain.Gender;
+import co.yapp.orbit.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = {"discord.webhook.url=http://dummy-url.com"})
+class UserPersistenceAdapterTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserPersistenceAdapter userPersistenceAdapter;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("UserPersistenceAdapter의 save 메서드가 도메인 객체를 DB에 저장하고 id를 반환한다.")
+    void save() {
+        User user = new User(null, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), Gender.MALE);
+        Long userId = userPersistenceAdapter.save(user);
+        assertThat(userId).isNotNull();
+        boolean exists = userRepository.findById(userId).isPresent();
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("UserPersistenceAdapter의 findById 메서드가 도메인 객체를 올바르게 반환한다.")
+    void findById() {
+        // given
+        UserEntity entity = new UserEntity("홍길동",
+            LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), Gender.MALE);
+        UserEntity savedEntity = userRepository.save(entity);
+        Long userId = savedEntity.getId();
+
+        // when
+        User user = userPersistenceAdapter.findById(userId).orElse(null);
+
+        // then
+        assertThat(user).isNotNull();
+        assertThat(user.getId()).isEqualTo(userId);
+        assertThat(user.getName()).isEqualTo("홍길동");
+        assertThat(user.getBirthDate()).isEqualTo(LocalDate.parse("2025-02-09"));
+        assertThat(user.getBirthTime()).isEqualTo(LocalTime.parse("08:30:00"));
+        assertThat(user.getGender()).isEqualTo(Gender.MALE);
+    }
+}

--- a/src/test/java/co/yapp/orbit/user/application/LoadUserServiceTest.java
+++ b/src/test/java/co/yapp/orbit/user/application/LoadUserServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import co.yapp.orbit.user.application.exception.UserNotFoundException;
 import co.yapp.orbit.user.application.port.out.LoadUserPort;
+import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
 import java.time.LocalDate;
@@ -37,6 +38,7 @@ class LoadUserServiceTest {
             "홍길동",
             LocalDate.parse("2025-02-09"),
             LocalTime.parse("08:30:00"),
+            CalendarType.SOLAR,
             Gender.MALE
         );
         when(loadUserPort.findById(userId)).thenReturn(Optional.of(user));

--- a/src/test/java/co/yapp/orbit/user/application/LoadUserServiceTest.java
+++ b/src/test/java/co/yapp/orbit/user/application/LoadUserServiceTest.java
@@ -1,0 +1,61 @@
+package co.yapp.orbit.user.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import co.yapp.orbit.user.application.exception.UserNotFoundException;
+import co.yapp.orbit.user.application.port.out.LoadUserPort;
+import co.yapp.orbit.user.domain.Gender;
+import co.yapp.orbit.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class LoadUserServiceTest {
+
+    private LoadUserService loadUserService;
+    private LoadUserPort loadUserPort;
+
+    @BeforeEach
+    void setUp() {
+        loadUserPort = Mockito.mock(LoadUserPort.class);
+        loadUserService = new LoadUserService(loadUserPort);
+    }
+
+    @Test
+    @DisplayName("사용자 조회 시, 존재하는 id이면 해당 사용자 객체를 반환한다.")
+    void loadUser_success() {
+        // given
+        Long userId = 1L;
+        User user = new User(
+            userId,
+            "홍길동",
+            LocalDate.parse("2025-02-09"),
+            LocalTime.parse("08:30:00"),
+            Gender.MALE
+        );
+        when(loadUserPort.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        User result = loadUserService.loadUser(userId);
+
+        // then
+        assertEquals(user, result);
+    }
+
+    @Test
+    @DisplayName("사용자 조회 시, 존재하지 않는 id이면 UserNotFoundException을 발생시킨다.")
+    void loadUser_notFound_throwsException() {
+        // given
+        Long userId = 1L;
+        when(loadUserPort.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(UserNotFoundException.class, () -> loadUserService.loadUser(userId));
+    }
+}

--- a/src/test/java/co/yapp/orbit/user/application/SaveUserServiceTest.java
+++ b/src/test/java/co/yapp/orbit/user/application/SaveUserServiceTest.java
@@ -27,7 +27,7 @@ class SaveUserServiceTest {
     @DisplayName("사용자 저장 시, 유효한 요청이면 생성된 사용자 id를 반환한다.")
     void saveUser_success() {
         // given
-        UserCommand command = new UserCommand("홍길동", "2025-02-09", "08:30:00", "MALE");
+        UserCommand command = new UserCommand("홍길동", "2025-02-09", "08:30:00", "SOLAR", "MALE");
         Long expectedId = 1L;
         when(saveUserPort.save(any(User.class))).thenReturn(expectedId);
 

--- a/src/test/java/co/yapp/orbit/user/application/SaveUserServiceTest.java
+++ b/src/test/java/co/yapp/orbit/user/application/SaveUserServiceTest.java
@@ -1,0 +1,41 @@
+package co.yapp.orbit.user.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.application.port.out.SaveUserPort;
+import co.yapp.orbit.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class SaveUserServiceTest {
+
+    private SaveUserService saveUserService;
+    private SaveUserPort saveUserPort;
+
+    @BeforeEach
+    void setUp() {
+        saveUserPort = Mockito.mock(SaveUserPort.class);
+        saveUserService = new SaveUserService(saveUserPort);
+    }
+
+    @Test
+    @DisplayName("사용자 저장 시, 유효한 요청이면 생성된 사용자 id를 반환한다.")
+    void saveUser_success() {
+        // given
+        UserCommand command = new UserCommand("홍길동", "2025-02-09", "08:30:00", "MALE");
+        Long expectedId = 1L;
+        when(saveUserPort.save(any(User.class))).thenReturn(expectedId);
+
+        // when
+        Long userId = saveUserService.saveUser(command);
+
+        // then
+        assertEquals(expectedId, userId);
+        verify(saveUserPort, times(1)).save(any(User.class));
+    }
+}

--- a/src/test/java/co/yapp/orbit/user/domain/UserTest.java
+++ b/src/test/java/co/yapp/orbit/user/domain/UserTest.java
@@ -15,10 +15,11 @@ class UserTest {
         String name = "홍길동";
         LocalDate birthDate = LocalDate.parse("2025-02-09");
         LocalTime birthTime = LocalTime.parse("08:30:00");
+        CalendarType calendarType = CalendarType.SOLAR;
         Gender gender = Gender.MALE;
 
-        User user1 = new User(id, name, birthDate, birthTime, gender);
-        User user2 = new User(id, name, birthDate, birthTime, gender);
+        User user1 = new User(id, name, birthDate, birthTime, calendarType, gender);
+        User user2 = new User(id, name, birthDate, birthTime, calendarType, gender);
 
         assertThat(user1)
             .isEqualTo(user2)
@@ -32,9 +33,10 @@ class UserTest {
         LocalDate birthDate = LocalDate.parse("2025-02-09");
         LocalTime birthTime = LocalTime.parse("08:30:00");
         Gender gender = Gender.MALE;
+        CalendarType calendarType = CalendarType.SOLAR;
 
-        User user1 = new User(1L, name, birthDate, birthTime, gender);
-        User user2 = new User(2L, name, birthDate, birthTime, gender);
+        User user1 = new User(1L, name, birthDate, birthTime, calendarType, gender);
+        User user2 = new User(2L, name, birthDate, birthTime, calendarType, gender);
 
         assertThat(user1).isNotEqualTo(user2);
     }
@@ -45,10 +47,11 @@ class UserTest {
         Long id = 1L;
         LocalDate birthDate = LocalDate.parse("2025-02-09");
         LocalTime birthTime = LocalTime.parse("08:30:00");
+        CalendarType calendarType = CalendarType.SOLAR;
         Gender gender = Gender.MALE;
 
-        User user1 = new User(id, "홍길동", birthDate, birthTime, gender);
-        User user2 = new User(id, "김철수", birthDate, birthTime, gender);
+        User user1 = new User(id, "홍길동", birthDate, birthTime, calendarType, gender);
+        User user2 = new User(id, "김철수", birthDate, birthTime, calendarType, gender);
 
         assertThat(user1).isNotEqualTo(user2);
     }
@@ -61,10 +64,11 @@ class UserTest {
         LocalDate birthDate1 = LocalDate.parse("2025-02-09");
         LocalDate birthDate2 = LocalDate.parse("2024-01-01");
         LocalTime birthTime = LocalTime.parse("08:30:00");
+        CalendarType calendarType = CalendarType.SOLAR;
         Gender gender = Gender.MALE;
 
-        User user1 = new User(id, name, birthDate1, birthTime, gender);
-        User user2 = new User(id, name, birthDate2, birthTime, gender);
+        User user1 = new User(id, name, birthDate1, birthTime, calendarType, gender);
+        User user2 = new User(id, name, birthDate2, birthTime, calendarType, gender);
 
         assertThat(user1).isNotEqualTo(user2);
     }
@@ -77,10 +81,11 @@ class UserTest {
         LocalDate birthDate = LocalDate.parse("2025-02-09");
         LocalTime birthTime1 = LocalTime.parse("08:30:00");
         LocalTime birthTime2 = LocalTime.parse("09:00:00");
+        CalendarType calendarType = CalendarType.SOLAR;
         Gender gender = Gender.MALE;
 
-        User user1 = new User(id, name, birthDate, birthTime1, gender);
-        User user2 = new User(id, name, birthDate, birthTime2, gender);
+        User user1 = new User(id, name, birthDate, birthTime1, calendarType, gender);
+        User user2 = new User(id, name, birthDate, birthTime2, calendarType, gender);
 
         assertThat(user1).isNotEqualTo(user2);
     }
@@ -92,9 +97,10 @@ class UserTest {
         String name = "홍길동";
         LocalDate birthDate = LocalDate.parse("2025-02-09");
         LocalTime birthTime = LocalTime.parse("08:30:00");
+        CalendarType calendarType = CalendarType.SOLAR;
 
-        User user1 = new User(id, name, birthDate, birthTime, Gender.MALE);
-        User user2 = new User(id, name, birthDate, birthTime, Gender.FEMALE);
+        User user1 = new User(id, name, birthDate, birthTime, calendarType, Gender.MALE);
+        User user2 = new User(id, name, birthDate, birthTime, calendarType, Gender.FEMALE);
 
         assertThat(user1).isNotEqualTo(user2);
     }
@@ -102,14 +108,14 @@ class UserTest {
     @Test
     @DisplayName("자기 자신과의 equals()는 true를 반환해야 한다.")
     void equals_itself_returnsTrue() {
-        User user = new User(1L, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), Gender.MALE);
+        User user = new User(1L, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), CalendarType.SOLAR, Gender.MALE);
         assertThat(user).isEqualTo(user);
     }
 
     @Test
     @DisplayName("다른 타입의 객체와 equals() 비교 시 false를 반환해야 한다.")
     void equals_differentType_returnsFalse() {
-        User user = new User(1L, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), Gender.MALE);
+        User user = new User(1L, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), CalendarType.SOLAR, Gender.MALE);
         String other = "some string";
         assertThat(user).isNotEqualTo(other);
     }

--- a/src/test/java/co/yapp/orbit/user/domain/UserTest.java
+++ b/src/test/java/co/yapp/orbit/user/domain/UserTest.java
@@ -1,0 +1,116 @@
+package co.yapp.orbit.user.domain;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Test
+    @DisplayName("동일한 id, 이름, 생년월일, 태어난시간, 성별을 가진 객체는 equals()가 true를 반환해야 한다.")
+    void equals_sameAttributes_returnsTrue() {
+        Long id = 1L;
+        String name = "홍길동";
+        LocalDate birthDate = LocalDate.parse("2025-02-09");
+        LocalTime birthTime = LocalTime.parse("08:30:00");
+        Gender gender = Gender.MALE;
+
+        User user1 = new User(id, name, birthDate, birthTime, gender);
+        User user2 = new User(id, name, birthDate, birthTime, gender);
+
+        assertThat(user1)
+            .isEqualTo(user2)
+            .hasSameHashCodeAs(user2);
+    }
+
+    @Test
+    @DisplayName("서로 다른 id를 가진 객체는 equals()가 false를 반환해야 한다.")
+    void equals_differentId_returnsFalse() {
+        String name = "홍길동";
+        LocalDate birthDate = LocalDate.parse("2025-02-09");
+        LocalTime birthTime = LocalTime.parse("08:30:00");
+        Gender gender = Gender.MALE;
+
+        User user1 = new User(1L, name, birthDate, birthTime, gender);
+        User user2 = new User(2L, name, birthDate, birthTime, gender);
+
+        assertThat(user1).isNotEqualTo(user2);
+    }
+
+    @Test
+    @DisplayName("서로 다른 이름을 가진 객체는 equals()가 false를 반환해야 한다.")
+    void equals_differentName_returnsFalse() {
+        Long id = 1L;
+        LocalDate birthDate = LocalDate.parse("2025-02-09");
+        LocalTime birthTime = LocalTime.parse("08:30:00");
+        Gender gender = Gender.MALE;
+
+        User user1 = new User(id, "홍길동", birthDate, birthTime, gender);
+        User user2 = new User(id, "김철수", birthDate, birthTime, gender);
+
+        assertThat(user1).isNotEqualTo(user2);
+    }
+
+    @Test
+    @DisplayName("서로 다른 생년월일을 가진 객체는 equals()가 false를 반환해야 한다.")
+    void equals_differentBirthDate_returnsFalse() {
+        Long id = 1L;
+        String name = "홍길동";
+        LocalDate birthDate1 = LocalDate.parse("2025-02-09");
+        LocalDate birthDate2 = LocalDate.parse("2024-01-01");
+        LocalTime birthTime = LocalTime.parse("08:30:00");
+        Gender gender = Gender.MALE;
+
+        User user1 = new User(id, name, birthDate1, birthTime, gender);
+        User user2 = new User(id, name, birthDate2, birthTime, gender);
+
+        assertThat(user1).isNotEqualTo(user2);
+    }
+
+    @Test
+    @DisplayName("서로 다른 태어난시간을 가진 객체는 equals()가 false를 반환해야 한다.")
+    void equals_differentBirthTime_returnsFalse() {
+        Long id = 1L;
+        String name = "홍길동";
+        LocalDate birthDate = LocalDate.parse("2025-02-09");
+        LocalTime birthTime1 = LocalTime.parse("08:30:00");
+        LocalTime birthTime2 = LocalTime.parse("09:00:00");
+        Gender gender = Gender.MALE;
+
+        User user1 = new User(id, name, birthDate, birthTime1, gender);
+        User user2 = new User(id, name, birthDate, birthTime2, gender);
+
+        assertThat(user1).isNotEqualTo(user2);
+    }
+
+    @Test
+    @DisplayName("서로 다른 성별을 가진 객체는 equals()가 false를 반환해야 한다.")
+    void equals_differentGender_returnsFalse() {
+        Long id = 1L;
+        String name = "홍길동";
+        LocalDate birthDate = LocalDate.parse("2025-02-09");
+        LocalTime birthTime = LocalTime.parse("08:30:00");
+
+        User user1 = new User(id, name, birthDate, birthTime, Gender.MALE);
+        User user2 = new User(id, name, birthDate, birthTime, Gender.FEMALE);
+
+        assertThat(user1).isNotEqualTo(user2);
+    }
+
+    @Test
+    @DisplayName("자기 자신과의 equals()는 true를 반환해야 한다.")
+    void equals_itself_returnsTrue() {
+        User user = new User(1L, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), Gender.MALE);
+        assertThat(user).isEqualTo(user);
+    }
+
+    @Test
+    @DisplayName("다른 타입의 객체와 equals() 비교 시 false를 반환해야 한다.")
+    void equals_differentType_returnsFalse() {
+        User user = new User(1L, "홍길동", LocalDate.parse("2025-02-09"), LocalTime.parse("08:30:00"), Gender.MALE);
+        String other = "some string";
+        assertThat(user).isNotEqualTo(other);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,38 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    open-in-view: false
+    show-sql: true
+    generate-ddl: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
+
+  h2:
+    console:
+      enabled: true
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    url: /docs/openapi3.json
+    path: /swagger-ui/index.html
+
+discord:
+  webhook:
+    url: TEST_DISCORD_WEBHOOK_URL
+
+gemini:
+  api:
+    url: TEST_GEMINI_URL
+    key: TEST_GEMINI_KEY


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #<issue_number>

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [x] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- Introduces a REST controller to handle creation requests for users.
- Provides the use case logic, including loading and saving new users.
- Defines the domain model and the corresponding JPA entity.
- Implements persistence logic for checking loading and saving user data to the database.
- Adds comprehensive unit and integration tests to ensure correctness of the new feature.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] Task1

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)