### PR TITLE
[YAF-127] Add OpenAPI 3 spec generation and API documentation tests

### DIFF
--- a/src/main/resources/static/docs/openapi3.json
+++ b/src/main/resources/static/docs/openapi3.json
@@ -111,6 +111,72 @@
         }
       }
     },
+    "/api/v1/prereservations" : {
+      "post" : {
+        "tags" : [ "PreReservation" ],
+        "summary" : "사전 예약 생성 API",
+        "description" : "사전 예약을 신청하는 API",
+        "operationId" : "prereservations-create",
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PreReservationCreateRequest"
+              },
+              "examples" : {
+                "prereservations-create" : {
+                  "value" : "{\n  \"email\" : \"byungwook-min@naver.com\",\n  \"phoneNumber\" : \"010-1234-5678\"\n}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "200"
+          }
+        }
+      }
+    },
+    "/api/v1/users" : {
+      "post" : {
+        "tags" : [ "User" ],
+        "summary" : "사용자 등록 API",
+        "description" : "사용자를 등록하는 API",
+        "operationId" : "users-create",
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SaveUserRequest"
+              },
+              "examples" : {
+                "users-create" : {
+                  "value" : "{\n  \"name\" : \"홍길동\",\n  \"birthDate\" : \"2025-02-09\",\n  \"birthTime\" : \"08:30:00\",\n  \"calendarType\" : \"SOLAR\",\n  \"gender\" : \"MALE\"\n}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/UserId"
+                },
+                "examples" : {
+                  "users-create" : {
+                    "value" : "1"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/fortunes/{fortuneId}" : {
       "get" : {
         "tags" : [ "Fortune" ],
@@ -159,6 +225,40 @@
           }
         }
       }
+    },
+    "/api/v1/users/{id}" : {
+      "get" : {
+        "tags" : [ "User" ],
+        "summary" : "사용자 조회 API",
+        "description" : "사용자 정보를 조회하는 API",
+        "operationId" : "users-get",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "사용자 ID",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "200",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/User"
+                },
+                "examples" : {
+                  "users-get" : {
+                    "value" : "{\n  \"id\" : 1,\n  \"name\" : \"홍길동\",\n  \"birthDate\" : \"2025-02-09\",\n  \"birthTime\" : \"08:30\",\n  \"calendarType\" : \"SOLAR\",\n  \"gender\" : \"MALE\"\n}"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components" : {
@@ -166,6 +266,83 @@
       "Exception" : {
         "title" : "Exception",
         "type" : "object"
+      },
+      "User" : {
+        "title" : "User",
+        "required" : [ "birthDate", "birthTime", "calendarType", "gender", "id", "name" ],
+        "type" : "object",
+        "properties" : {
+          "calendarType" : {
+            "type" : "string",
+            "description" : "달력 타입 (SOLAR, LUNAR 등)"
+          },
+          "gender" : {
+            "type" : "string",
+            "description" : "사용자의 성"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "사용자의 이름"
+          },
+          "birthTime" : {
+            "type" : "string",
+            "description" : "사용자의 출생시간 (HH:mm:ss)"
+          },
+          "id" : {
+            "type" : "number",
+            "description" : "사용자 ID"
+          },
+          "birthDate" : {
+            "type" : "string",
+            "description" : "사용자의 생년월일 (yyyy-MM-dd)"
+          }
+        }
+      },
+      "UserId" : {
+        "title" : "UserId",
+        "type" : "object"
+      },
+      "SaveUserRequest" : {
+        "title" : "SaveUserRequest",
+        "required" : [ "birthDate", "birthTime", "calendarType", "gender", "name" ],
+        "type" : "object",
+        "properties" : {
+          "calendarType" : {
+            "type" : "string",
+            "description" : "달력 타입 (SOLAR, LUNAR 등)"
+          },
+          "gender" : {
+            "type" : "string",
+            "description" : "사용자의 성별 (MALE, FEMALE 등)"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "사용자의 이름"
+          },
+          "birthTime" : {
+            "type" : "string",
+            "description" : "사용자의 출생시간 (HH:mm:ss)"
+          },
+          "birthDate" : {
+            "type" : "string",
+            "description" : "사용자의 생년월일 (yyyy-MM-dd)"
+          }
+        }
+      },
+      "PreReservationCreateRequest" : {
+        "title" : "PreReservationCreateRequest",
+        "required" : [ "email", "phoneNumber" ],
+        "type" : "object",
+        "properties" : {
+          "phoneNumber" : {
+            "type" : "string",
+            "description" : "사전 예약을 신청하는 사용자의 전화번호"
+          },
+          "email" : {
+            "type" : "string",
+            "description" : "사전 예약을 신청하는 사용자의 이메일 주소"
+          }
+        }
       },
       "Fortune" : {
         "title" : "Fortune",

--- a/src/test/java/co/yapp/orbit/prereservation/adapter/in/PreReservationControllerDocumentTest.java
+++ b/src/test/java/co/yapp/orbit/prereservation/adapter/in/PreReservationControllerDocumentTest.java
@@ -1,0 +1,79 @@
+package co.yapp.orbit.prereservation.adapter.in;
+
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import co.yapp.orbit.prereservation.adapter.in.request.PreReservationCreateRequest;
+import co.yapp.orbit.prereservation.application.port.in.CreatePreReservationUseCase;
+import co.yapp.orbit.prereservation.application.port.in.PreReservationCommand;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = PreReservationController.class)
+@AutoConfigureRestDocs(uriScheme = "https", uriHost = "dev.orbitalarm.net", uriPort = 443)
+@ExtendWith(RestDocumentationExtension.class)
+class PreReservationControllerDocumentTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CreatePreReservationUseCase createPreReservationUseCase;
+
+    @Test
+    @DisplayName("문서화: 사전 예약 생성 API")
+    void createPreReservation_document() throws Exception {
+        // given
+        PreReservationCreateRequest request = new PreReservationCreateRequest(
+            "byungwook-min@naver.com", "010-1234-5678");
+        String json = objectMapper.writeValueAsString(request);
+
+        Mockito.doNothing().when(createPreReservationUseCase)
+            .createPreReservation(any(PreReservationCommand.class));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/prereservations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isOk())
+            .andDo(document("prereservations-create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(ResourceSnippetParameters.builder()
+                    .tag("PreReservation")
+                    .summary("사전 예약 생성 API")
+                    .description("사전 예약을 신청하는 API")
+                    .requestFields(
+                        fieldWithPath("email")
+                            .description("사전 예약을 신청하는 사용자의 이메일 주소"),
+                        fieldWithPath("phoneNumber")
+                            .description("사전 예약을 신청하는 사용자의 전화번호")
+                    )
+                    .requestSchema(Schema.schema("PreReservationCreateRequest"))
+                    .build()
+            )));
+    }
+}

--- a/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerDocumentTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerDocumentTest.java
@@ -1,0 +1,150 @@
+package co.yapp.orbit.user.adapter.in;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.ArgumentMatchers.any;
+
+import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
+import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
+import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
+import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.domain.CalendarType;
+import co.yapp.orbit.user.domain.Gender;
+import co.yapp.orbit.user.domain.User;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = UserController.class)
+@AutoConfigureRestDocs(uriScheme = "https", uriHost = "dev.orbitalarm.net", uriPort = 443)
+@ExtendWith(RestDocumentationExtension.class)
+class UserControllerDocumentTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private SaveUserUseCase saveUserUseCase;
+
+    @MockitoBean
+    private LoadUserUseCase getUserUseCase;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider restDocumentation) {
+        // AutoConfigureRestDocs가 이미 설정을 처리합니다.
+    }
+
+    @Test
+    @DisplayName("문서화: 사용자 등록 API")
+    void createUser_document() throws Exception {
+        // given
+        SaveUserRequest request = new SaveUserRequest(
+            "홍길동", "2025-02-09", "08:30:00", "SOLAR", "MALE");
+        String json = objectMapper.writeValueAsString(request);
+
+        Mockito.when(saveUserUseCase.saveUser(any(UserCommand.class)))
+            .thenReturn(1L);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isOk())
+            .andDo(document("users-create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(ResourceSnippetParameters.builder()
+                    .tag("User")
+                    .summary("사용자 등록 API")
+                    .description("사용자를 등록하는 API")
+                    .requestFields(
+                        fieldWithPath("name")
+                            .description("사용자의 이름"),
+                        fieldWithPath("birthDate")
+                            .description("사용자의 생년월일 (yyyy-MM-dd)"),
+                        fieldWithPath("birthTime")
+                            .description("사용자의 출생시간 (HH:mm:ss)"),
+                        fieldWithPath("calendarType")
+                            .description("달력 타입 (SOLAR, LUNAR 등)"),
+                        fieldWithPath("gender")
+                            .description("사용자의 성별 (MALE, FEMALE 등)")
+                    )
+                    .requestSchema(Schema.schema("SaveUserRequest"))
+                    // 응답이 사용자 ID(Long)인 경우 해당 스키마를 정의합니다.
+                    .responseSchema(Schema.schema("UserId"))
+                    .build()
+            )));
+    }
+
+    @Test
+    @DisplayName("문서화: 사용자 조회 API")
+    void getUser_document() throws Exception {
+        // given
+        Long userId = 1L;
+        User user = new User(
+            userId,
+            "홍길동",
+            java.time.LocalDate.parse("2025-02-09"),
+            java.time.LocalTime.parse("08:30:00"),
+            CalendarType.SOLAR,
+            Gender.MALE
+        );
+        Mockito.when(getUserUseCase.loadUser(userId)).thenReturn(user);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/users/{id}", userId))
+            .andExpect(status().isOk())
+            .andDo(document("users-get",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(ResourceSnippetParameters.builder()
+                    .tag("User")
+                    .summary("사용자 조회 API")
+                    .description("사용자 정보를 조회하는 API")
+                    .pathParameters(
+                        parameterWithName("id").description("사용자 ID")
+                    )
+                    .responseFields(
+                        fieldWithPath("id")
+                            .description("사용자 ID"),
+                        fieldWithPath("name")
+                            .description("사용자의 이름"),
+                        fieldWithPath("birthDate")
+                            .description("사용자의 생년월일 (yyyy-MM-dd)"),
+                        fieldWithPath("birthTime")
+                            .description("사용자의 출생시간 (HH:mm:ss)"),
+                        fieldWithPath("calendarType")
+                            .description("달력 타입 (SOLAR, LUNAR 등)"),
+                        fieldWithPath("gender")
+                            .description("사용자의 성")
+                    )
+                    .requestSchema(Schema.schema("GET User Parameters"))
+                    .responseSchema(Schema.schema("User"))
+                    .build()
+            )));
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #<issue_number>

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [x] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [ ] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- Generate openapi3.json with paths and schemas for /api/v1/prereservations and /api/v1/users endpoints.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] Task1

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)