### PR TITLE
[YAF-128] Add UpdateUser API with domain, persistence, tests, and Update BirthTime Nullable 

### DIFF
--- a/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
@@ -1,10 +1,13 @@
 package co.yapp.orbit.user.adapter.in;
 
 import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
+import co.yapp.orbit.user.adapter.in.request.UpdateUserRequest;
 import co.yapp.orbit.user.adapter.in.response.LoadUserResponse;
 import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserCommand;
+import co.yapp.orbit.user.application.port.in.UpdateUserCommand;
+import co.yapp.orbit.user.application.port.in.UpdateUserUseCase;
 import co.yapp.orbit.user.domain.User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,10 +18,12 @@ public class UserController {
 
     private final SaveUserUseCase createUserUseCase;
     private final LoadUserUseCase getUserUseCase;
+    private final UpdateUserUseCase updateUserUseCase;
 
-    public UserController(SaveUserUseCase createUserUseCase, LoadUserUseCase getUserUseCase) {
+    public UserController(SaveUserUseCase createUserUseCase, LoadUserUseCase getUserUseCase, UpdateUserUseCase updateUserUseCase) {
         this.createUserUseCase = createUserUseCase;
         this.getUserUseCase = getUserUseCase;
+        this.updateUserUseCase = updateUserUseCase;
     }
 
     @PostMapping
@@ -46,5 +51,18 @@ public class UserController {
             user.getGender().name()
         );
         return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> updateUser(@PathVariable("id") Long id, @RequestBody UpdateUserRequest request) {
+        UpdateUserCommand command = new UpdateUserCommand(
+            request.getName(),
+            request.getBirthDate(),
+            request.getBirthTime(),
+            request.getCalendarType(),
+            request.getGender()
+        );
+        updateUserUseCase.updateUser(id, command);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
@@ -4,7 +4,7 @@ import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
 import co.yapp.orbit.user.adapter.in.response.LoadUserResponse;
 import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
-import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.application.port.in.SaveUserCommand;
 import co.yapp.orbit.user.domain.User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +23,7 @@ public class UserController {
 
     @PostMapping
     public ResponseEntity<Long> createUser(@RequestBody SaveUserRequest request) {
-        UserCommand command = new UserCommand(
+        SaveUserCommand command = new SaveUserCommand(
             request.getName(),
             request.getBirthDate(),
             request.getBirthTime(),

--- a/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/UserController.java
@@ -43,13 +43,7 @@ public class UserController {
     public ResponseEntity<LoadUserResponse> getUser(@PathVariable("id") Long id) {
         User user = getUserUseCase.loadUser(id);
         LoadUserResponse response = new LoadUserResponse(
-            user.getId(),
-            user.getName(),
-            user.getBirthDate().toString(),
-            user.getBirthTime().toString(),
-            user.getCalendarType().toString(),
-            user.getGender().name()
-        );
+            user);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/co/yapp/orbit/user/adapter/in/request/UpdateUserRequest.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/request/UpdateUserRequest.java
@@ -1,0 +1,23 @@
+package co.yapp.orbit.user.adapter.in.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateUserRequest {
+
+    private String name;
+    private String birthDate;
+    private String birthTime;
+    private String calendarType;
+    private String gender;
+
+    public UpdateUserRequest(String name, String birthDate, String birthTime, String calendarType, String gender) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.birthTime = birthTime;
+        this.calendarType = calendarType;
+        this.gender = gender;
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/adapter/in/response/LoadUserResponse.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/in/response/LoadUserResponse.java
@@ -1,5 +1,7 @@
 package co.yapp.orbit.user.adapter.in.response;
 
+import co.yapp.orbit.user.domain.User;
+import java.time.LocalTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,12 +16,17 @@ public class LoadUserResponse {
     private String calendarType;
     private String gender;
 
-    public LoadUserResponse(Long id, String name, String birthDate, String birthTime, String calendarType, String gender) {
-        this.id = id;
-        this.name = name;
-        this.birthDate = birthDate;
-        this.birthTime = birthTime;
-        this.gender = gender;
-        this.calendarType = calendarType;
+    public LoadUserResponse(User user) {
+        this.id = user.getId();
+        this.name = user.getName();
+        this.birthDate = user.getBirthDate().toString();
+        LocalTime birthTime = user.getBirthTime();
+        if (birthTime == null) {
+            this.birthTime = null;
+        } else {
+            this.birthTime = birthTime.toString();
+        }
+        this.gender = user.getGender().toString();
+        this.calendarType = user.getCalendarType().toString();
     }
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserEntity.java
@@ -45,4 +45,12 @@ public class UserEntity extends BaseTimeEntity {
         this.calendarType = calendarType;
         this.gender = gender;
     }
+
+    public void update(String name, LocalDate birthDate, LocalTime birthTime, CalendarType calendarType, Gender gender) {
+        this.name = name;
+        this.birthDate = birthDate;
+        this.birthTime = birthTime;
+        this.calendarType = calendarType;
+        this.gender = gender;
+    }
 }

--- a/src/main/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapter.java
+++ b/src/main/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapter.java
@@ -1,13 +1,15 @@
 package co.yapp.orbit.user.adapter.out;
 
+import co.yapp.orbit.user.application.exception.UserNotFoundException;
 import co.yapp.orbit.user.application.port.out.LoadUserPort;
 import co.yapp.orbit.user.application.port.out.SaveUserPort;
+import co.yapp.orbit.user.application.port.out.UpdateUserPort;
 import co.yapp.orbit.user.domain.User;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UserPersistenceAdapter implements SaveUserPort, LoadUserPort {
+public class UserPersistenceAdapter implements SaveUserPort, LoadUserPort, UpdateUserPort {
 
     private final UserRepository userRepository;
 
@@ -39,5 +41,19 @@ public class UserPersistenceAdapter implements SaveUserPort, LoadUserPort {
                 entity.getCalendarType(),
                 entity.getGender()
             ));
+    }
+
+    @Override
+    public void update(User user) {
+        UserEntity entity = userRepository.findById(user.getId())
+            .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다. id: " + user.getId()));
+        entity.update(
+            user.getName(),
+            user.getBirthDate(),
+            user.getBirthTime(),
+            user.getCalendarType(),
+            user.getGender()
+        );
+        userRepository.save(entity);
     }
 }

--- a/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
@@ -1,7 +1,7 @@
 package co.yapp.orbit.user.application;
 
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
-import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.application.port.in.SaveUserCommand;
 import co.yapp.orbit.user.application.port.out.SaveUserPort;
 import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
@@ -22,7 +22,7 @@ public class SaveUserService implements SaveUserUseCase {
 
     @Transactional
     @Override
-    public Long saveUser(UserCommand command) {
+    public Long saveUser(SaveUserCommand command) {
         LocalDate birthDate = LocalDate.parse(command.birthDate());
         LocalTime birthTime = LocalTime.parse(command.birthTime());
         Gender gender = Gender.valueOf(command.gender().toUpperCase());

--- a/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/SaveUserService.java
@@ -24,7 +24,13 @@ public class SaveUserService implements SaveUserUseCase {
     @Override
     public Long saveUser(SaveUserCommand command) {
         LocalDate birthDate = LocalDate.parse(command.birthDate());
-        LocalTime birthTime = LocalTime.parse(command.birthTime());
+        LocalTime birthTime;
+        if (command.birthTime() == null || command.birthTime().trim().isEmpty()) {
+            birthTime = null;
+        }
+        else {
+            birthTime = LocalTime.parse(command.birthTime());
+        }
         Gender gender = Gender.valueOf(command.gender().toUpperCase());
         CalendarType calendarType = CalendarType.valueOf(command.calendarType().toUpperCase());
         User user = new User(null, command.name(), birthDate, birthTime, calendarType, gender);

--- a/src/main/java/co/yapp/orbit/user/application/UpdateUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/UpdateUserService.java
@@ -24,7 +24,13 @@ public class UpdateUserService implements UpdateUserUseCase {
     @Override
     public void updateUser(Long id, UpdateUserCommand command) {
         LocalDate birthDate = LocalDate.parse(command.birthDate());
-        LocalTime birthTime = LocalTime.parse(command.birthTime());
+        LocalTime birthTime;
+        if (command.birthTime() == null || command.birthTime().trim().isEmpty()) {
+            birthTime = null;
+        }
+        else {
+            birthTime = LocalTime.parse(command.birthTime());
+        }
         Gender gender = Gender.valueOf(command.gender().toUpperCase());
         CalendarType calendarType = CalendarType.valueOf(command.calendarType().toUpperCase());
 

--- a/src/main/java/co/yapp/orbit/user/application/UpdateUserService.java
+++ b/src/main/java/co/yapp/orbit/user/application/UpdateUserService.java
@@ -1,0 +1,34 @@
+package co.yapp.orbit.user.application;
+
+import co.yapp.orbit.user.application.port.in.UpdateUserCommand;
+import co.yapp.orbit.user.application.port.in.UpdateUserUseCase;
+import co.yapp.orbit.user.application.port.out.UpdateUserPort;
+import co.yapp.orbit.user.domain.CalendarType;
+import co.yapp.orbit.user.domain.Gender;
+import co.yapp.orbit.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class UpdateUserService implements UpdateUserUseCase {
+
+    private final UpdateUserPort updateUserPort;
+
+    public UpdateUserService(UpdateUserPort updateUserPort) {
+        this.updateUserPort = updateUserPort;
+    }
+
+    @Transactional
+    @Override
+    public void updateUser(Long id, UpdateUserCommand command) {
+        LocalDate birthDate = LocalDate.parse(command.birthDate());
+        LocalTime birthTime = LocalTime.parse(command.birthTime());
+        Gender gender = Gender.valueOf(command.gender().toUpperCase());
+        CalendarType calendarType = CalendarType.valueOf(command.calendarType().toUpperCase());
+
+        User updatedUser = new User(id, command.name(), birthDate, birthTime, calendarType, gender);
+        updateUserPort.update(updatedUser);
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserCommand.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserCommand.java
@@ -2,8 +2,8 @@ package co.yapp.orbit.user.application.port.in;
 
 import co.yapp.orbit.user.application.exception.InvalidUserCommandException;
 
-public record UserCommand(String name, String birthDate, String birthTime, String calendarType, String gender) {
-    public UserCommand {
+public record SaveUserCommand(String name, String birthDate, String birthTime, String calendarType, String gender) {
+    public SaveUserCommand {
         if (name == null || name.trim().isEmpty()) {
             throw new InvalidUserCommandException("이름(name)은 null 또는 빈 값일 수 없습니다.");
         }

--- a/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserCommand.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserCommand.java
@@ -2,7 +2,13 @@ package co.yapp.orbit.user.application.port.in;
 
 import co.yapp.orbit.user.application.exception.InvalidUserCommandException;
 
-public record SaveUserCommand(String name, String birthDate, String birthTime, String calendarType, String gender) {
+public record SaveUserCommand(
+    String name,
+    String birthDate,
+    String birthTime,
+    String calendarType,
+    String gender)
+{
     public SaveUserCommand {
         if (name == null || name.trim().isEmpty()) {
             throw new InvalidUserCommandException("이름(name)은 null 또는 빈 값일 수 없습니다.");

--- a/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserUseCase.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/SaveUserUseCase.java
@@ -2,5 +2,5 @@ package co.yapp.orbit.user.application.port.in;
 
 public interface SaveUserUseCase {
 
-    Long saveUser(UserCommand command);
+    Long saveUser(SaveUserCommand command);
 }

--- a/src/main/java/co/yapp/orbit/user/application/port/in/UpdateUserCommand.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/UpdateUserCommand.java
@@ -1,9 +1,26 @@
 package co.yapp.orbit.user.application.port.in;
 
+import co.yapp.orbit.user.application.exception.InvalidUserCommandException;
+
 public record UpdateUserCommand(
     String name,
     String birthDate,
     String birthTime,
     String calendarType,
     String gender
-) {}
+) {
+    public UpdateUserCommand {
+        if (name == null || name.trim().isEmpty()) {
+            throw new InvalidUserCommandException("이름(name)은 null 또는 빈 값일 수 없습니다.");
+        }
+        if (birthDate == null || birthDate.trim().isEmpty()) {
+            throw new InvalidUserCommandException("생년월일(birthDate)는 null 또는 빈 값일 수 없습니다.");
+        }
+        if (calendarType == null || calendarType.trim().isEmpty()) {
+            throw new InvalidUserCommandException("음력/양력(calendarType)는 null 또는 빈 값일 수 없습니다.");
+        }
+        if (gender == null || gender.trim().isEmpty()) {
+            throw new InvalidUserCommandException("성별(gender)는 null 또는 빈 값일 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/in/UpdateUserCommand.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/UpdateUserCommand.java
@@ -1,0 +1,9 @@
+package co.yapp.orbit.user.application.port.in;
+
+public record UpdateUserCommand(
+    String name,
+    String birthDate,
+    String birthTime,
+    String calendarType,
+    String gender
+) {}

--- a/src/main/java/co/yapp/orbit/user/application/port/in/UpdateUserUseCase.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/in/UpdateUserUseCase.java
@@ -1,0 +1,5 @@
+package co.yapp.orbit.user.application.port.in;
+
+public interface UpdateUserUseCase {
+    void updateUser(Long id, UpdateUserCommand command);
+}

--- a/src/main/java/co/yapp/orbit/user/application/port/out/UpdateUserPort.java
+++ b/src/main/java/co/yapp/orbit/user/application/port/out/UpdateUserPort.java
@@ -1,0 +1,7 @@
+package co.yapp.orbit.user.application.port.out;
+
+import co.yapp.orbit.user.domain.User;
+
+public interface UpdateUserPort {
+    void update(User user);
+}

--- a/src/main/resources/static/docs/openapi3.json
+++ b/src/main/resources/static/docs/openapi3.json
@@ -258,18 +258,48 @@
             }
           }
         }
+      },
+      "put" : {
+        "tags" : [ "User" ],
+        "summary" : "사용자 수정 API",
+        "description" : "사용자 정보를 수정하는 API (전체 덮어쓰기 방식)",
+        "operationId" : "users-update",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "수정할 사용자 ID",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json;charset=UTF-8" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/UpdateUserRequest"
+              },
+              "examples" : {
+                "users-update" : {
+                  "value" : "{\n  \"name\" : \"홍길동\",\n  \"birthDate\" : \"2025-02-09\",\n  \"birthTime\" : \"08:30:00\",\n  \"calendarType\" : \"SOLAR\",\n  \"gender\" : \"MALE\"\n}"
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "204"
+          }
+        }
       }
     }
   },
   "components" : {
     "schemas" : {
-      "Exception" : {
-        "title" : "Exception",
-        "type" : "object"
-      },
-      "User" : {
-        "title" : "User",
-        "required" : [ "birthDate", "birthTime", "calendarType", "gender", "id", "name" ],
+      "UpdateUserRequest" : {
+        "title" : "UpdateUserRequest",
+        "required" : [ "birthDate", "birthTime", "calendarType", "gender", "name" ],
         "type" : "object",
         "properties" : {
           "calendarType" : {
@@ -278,7 +308,7 @@
           },
           "gender" : {
             "type" : "string",
-            "description" : "사용자의 성"
+            "description" : "사용자의 성별 (MALE, FEMALE 등)"
           },
           "name" : {
             "type" : "string",
@@ -286,11 +316,7 @@
           },
           "birthTime" : {
             "type" : "string",
-            "description" : "사용자의 출생시간 (HH:mm:ss)"
-          },
-          "id" : {
-            "type" : "number",
-            "description" : "사용자 ID"
+            "description" : "사용자의 출생시간 (HH:mm)"
           },
           "birthDate" : {
             "type" : "string",
@@ -298,8 +324,8 @@
           }
         }
       },
-      "UserId" : {
-        "title" : "UserId",
+      "Exception" : {
+        "title" : "Exception",
         "type" : "object"
       },
       "SaveUserRequest" : {
@@ -321,7 +347,42 @@
           },
           "birthTime" : {
             "type" : "string",
-            "description" : "사용자의 출생시간 (HH:mm:ss)"
+            "description" : "사용자의 출생시간 (HH:mm)"
+          },
+          "birthDate" : {
+            "type" : "string",
+            "description" : "사용자의 생년월일 (yyyy-MM-dd)"
+          }
+        }
+      },
+      "UserId" : {
+        "title" : "UserId",
+        "type" : "object"
+      },
+      "User" : {
+        "title" : "User",
+        "required" : [ "birthDate", "birthTime", "calendarType", "gender", "id", "name" ],
+        "type" : "object",
+        "properties" : {
+          "calendarType" : {
+            "type" : "string",
+            "description" : "달력 타입 (SOLAR, LUNAR 등)"
+          },
+          "gender" : {
+            "type" : "string",
+            "description" : "사용자의 성"
+          },
+          "name" : {
+            "type" : "string",
+            "description" : "사용자의 이름"
+          },
+          "birthTime" : {
+            "type" : "string",
+            "description" : "사용자의 출생시간 (HH:mm)"
+          },
+          "id" : {
+            "type" : "number",
+            "description" : "사용자 ID"
           },
           "birthDate" : {
             "type" : "string",

--- a/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerDocumentTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerDocumentTest.java
@@ -15,7 +15,7 @@ import static org.mockito.ArgumentMatchers.any;
 import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
 import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
-import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.application.port.in.SaveUserCommand;
 import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
@@ -66,7 +66,7 @@ class UserControllerDocumentTest {
             "홍길동", "2025-02-09", "08:30:00", "SOLAR", "MALE");
         String json = objectMapper.writeValueAsString(request);
 
-        Mockito.when(saveUserUseCase.saveUser(any(UserCommand.class)))
+        Mockito.when(saveUserUseCase.saveUser(any(SaveUserCommand.class)))
             .thenReturn(1L);
 
         // when & then

--- a/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerDocumentTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerDocumentTest.java
@@ -3,26 +3,30 @@ package co.yapp.orbit.user.adapter.in;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.mockito.ArgumentMatchers.any;
 
 import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
+import co.yapp.orbit.user.adapter.in.request.UpdateUserRequest;
 import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserCommand;
+import co.yapp.orbit.user.application.port.in.UpdateUserCommand;
+import co.yapp.orbit.user.application.port.in.UpdateUserUseCase;
 import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +35,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -53,10 +56,8 @@ class UserControllerDocumentTest {
     @MockitoBean
     private LoadUserUseCase getUserUseCase;
 
-    @BeforeEach
-    void setUp(RestDocumentationContextProvider restDocumentation) {
-        // AutoConfigureRestDocs가 이미 설정을 처리합니다.
-    }
+    @MockitoBean
+    private UpdateUserUseCase updateUserUseCase;
 
     @Test
     @DisplayName("문서화: 사용자 등록 API")
@@ -87,7 +88,7 @@ class UserControllerDocumentTest {
                         fieldWithPath("birthDate")
                             .description("사용자의 생년월일 (yyyy-MM-dd)"),
                         fieldWithPath("birthTime")
-                            .description("사용자의 출생시간 (HH:mm:ss)"),
+                            .description("사용자의 출생시간 (HH:mm)"),
                         fieldWithPath("calendarType")
                             .description("달력 타입 (SOLAR, LUNAR 등)"),
                         fieldWithPath("gender")
@@ -136,7 +137,7 @@ class UserControllerDocumentTest {
                         fieldWithPath("birthDate")
                             .description("사용자의 생년월일 (yyyy-MM-dd)"),
                         fieldWithPath("birthTime")
-                            .description("사용자의 출생시간 (HH:mm:ss)"),
+                            .description("사용자의 출생시간 (HH:mm)"),
                         fieldWithPath("calendarType")
                             .description("달력 타입 (SOLAR, LUNAR 등)"),
                         fieldWithPath("gender")
@@ -146,5 +147,44 @@ class UserControllerDocumentTest {
                     .responseSchema(Schema.schema("User"))
                     .build()
             )));
+    }
+
+    @Test
+    @DisplayName("문서화: 사용자 수정 API")
+    void updateUser_document() throws Exception {
+        // given
+        Long userId = 1L;
+        UpdateUserRequest request = new UpdateUserRequest(
+            "홍길동", "2025-02-09", "08:30:00", "SOLAR", "MALE"
+        );
+        String json = objectMapper.writeValueAsString(request);
+
+        Mockito.doNothing().when(updateUserUseCase).updateUser(eq(userId), any(UpdateUserCommand.class));
+
+        // when & then
+        mockMvc.perform(put("/api/v1/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isNoContent())
+            .andDo(document("users-update",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(ResourceSnippetParameters.builder()
+                    .tag("User")
+                    .summary("사용자 수정 API")
+                    .description("사용자 정보를 수정하는 API (전체 덮어쓰기 방식)")
+                    .pathParameters(
+                        parameterWithName("id").description("수정할 사용자 ID")
+                    )
+                    .requestFields(
+                        fieldWithPath("name").description("사용자의 이름"),
+                        fieldWithPath("birthDate").description("사용자의 생년월일 (yyyy-MM-dd)"),
+                        fieldWithPath("birthTime").description("사용자의 출생시간 (HH:mm)"),
+                        fieldWithPath("calendarType").description("달력 타입 (SOLAR, LUNAR 등)"),
+                        fieldWithPath("gender").description("사용자의 성별 (MALE, FEMALE 등)")
+                    )
+                    .requestSchema(Schema.schema("UpdateUserRequest"))
+                    .build()
+                )));
     }
 }

--- a/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerTest.java
@@ -11,7 +11,7 @@ import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
 import co.yapp.orbit.user.application.exception.UserNotFoundException;
 import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
-import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.application.port.in.SaveUserCommand;
 import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
@@ -47,7 +47,7 @@ class UserControllerTest {
     void saveUser_success() throws Exception {
         // given
         Long userId = 1L;
-        Mockito.when(saveUserUseCase.saveUser(any(UserCommand.class)))
+        Mockito.when(saveUserUseCase.saveUser(any(SaveUserCommand.class)))
             .thenReturn(userId);
 
         SaveUserRequest request = new SaveUserRequest("홍길동", "2025-02-09", "08:30:00", "SOLAR",
@@ -93,7 +93,7 @@ class UserControllerTest {
         String json = objectMapper.writeValueAsString(request);
 
         Mockito.doThrow(new IllegalArgumentException("No enum constant"))
-            .when(saveUserUseCase).saveUser(any(UserCommand.class));
+            .when(saveUserUseCase).saveUser(any(SaveUserCommand.class));
 
         mockMvc.perform(post("/api/v1/users")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/in/UserControllerTest.java
@@ -1,17 +1,22 @@
 package co.yapp.orbit.user.adapter.in;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import co.yapp.orbit.user.adapter.in.request.SaveUserRequest;
+import co.yapp.orbit.user.adapter.in.request.UpdateUserRequest;
 import co.yapp.orbit.user.application.exception.UserNotFoundException;
 import co.yapp.orbit.user.application.port.in.LoadUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserUseCase;
 import co.yapp.orbit.user.application.port.in.SaveUserCommand;
+import co.yapp.orbit.user.application.port.in.UpdateUserCommand;
+import co.yapp.orbit.user.application.port.in.UpdateUserUseCase;
 import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
@@ -41,6 +46,10 @@ class UserControllerTest {
 
     @MockitoBean
     private LoadUserUseCase getUserUseCase;
+
+    @MockitoBean
+    private UpdateUserUseCase updateUserUseCase;
+
 
     @Test
     @DisplayName("사용자 등록 성공 시 200 OK와 사용자 id를 반환한다.")
@@ -133,5 +142,20 @@ class UserControllerTest {
             .andExpect(jsonPath("$.birthDate").value("2025-02-09"))
             .andExpect(jsonPath("$.birthTime").value("08:30"))
             .andExpect(jsonPath("$.gender").value("MALE"));
+    }
+
+    @Test
+    @DisplayName("사용자 수정 성공 시 204 No Content를 반환한다.")
+    void updateUser_success() throws Exception {
+        Long userId = 1L;
+        UpdateUserRequest request = new UpdateUserRequest("홍길동", "2025-02-09", "08:30:00", "SOLAR", "MALE");
+        String json = objectMapper.writeValueAsString(request);
+
+        Mockito.doNothing().when(updateUserUseCase).updateUser(eq(userId), any(UpdateUserCommand.class));
+
+        mockMvc.perform(put("/api/v1/users/{id}", userId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+            .andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
@@ -61,8 +61,6 @@ class UserPersistenceAdapterTest {
         User foundUser = optionalUser.get();
         assertThat(foundUser.getId()).isEqualTo(userId);
         assertThat(foundUser.getName()).isEqualTo("홍길동");
-        assertThat(foundUser.getBirthDate()).isEqualTo(LocalDate.parse("2025-02-09"));
-        assertThat(foundUser.getBirthTime()).isEqualTo(LocalTime.parse("08:30:00"));
         assertThat(foundUser.getCalendarType()).isEqualTo(CalendarType.SOLAR);
         assertThat(foundUser.getGender()).isEqualTo(Gender.MALE);
     }
@@ -91,8 +89,6 @@ class UserPersistenceAdapterTest {
         assertThat(optionalUser).isPresent();
         User foundUser = optionalUser.get();
         assertThat(foundUser.getName()).isEqualTo("김철수");
-        assertThat(foundUser.getBirthDate()).isEqualTo(LocalDate.parse("2025-03-10"));
-        assertThat(foundUser.getBirthTime()).isEqualTo(LocalTime.parse("09:00:00"));
         assertThat(foundUser.getCalendarType()).isEqualTo(CalendarType.LUNAR);
         assertThat(foundUser.getGender()).isEqualTo(Gender.MALE);
     }

--- a/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
+++ b/src/test/java/co/yapp/orbit/user/adapter/out/UserPersistenceAdapterTest.java
@@ -1,12 +1,15 @@
 package co.yapp.orbit.user.adapter.out;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
 
+import co.yapp.orbit.user.application.exception.UserNotFoundException;
 import co.yapp.orbit.user.domain.CalendarType;
 import co.yapp.orbit.user.domain.Gender;
 import co.yapp.orbit.user.domain.User;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,5 +40,77 @@ class UserPersistenceAdapterTest {
         assertThat(userId).isNotNull();
         boolean exists = userRepository.findById(userId).isPresent();
         assertThat(exists).isTrue();
+    }
+
+    @Test
+    @DisplayName("UserPersistenceAdapter의 findById 메서드가 DB에서 사용자 정보를 조회한다.")
+    void findById() {
+        // given
+        User user = new User(null, "홍길동",
+            LocalDate.parse("2025-02-09"),
+            LocalTime.parse("08:30:00"),
+            CalendarType.SOLAR,
+            Gender.MALE);
+        Long userId = userPersistenceAdapter.save(user);
+
+        // when
+        Optional<User> optionalUser = userPersistenceAdapter.findById(userId);
+
+        // then
+        assertThat(optionalUser).isPresent();
+        User foundUser = optionalUser.get();
+        assertThat(foundUser.getId()).isEqualTo(userId);
+        assertThat(foundUser.getName()).isEqualTo("홍길동");
+        assertThat(foundUser.getBirthDate()).isEqualTo(LocalDate.parse("2025-02-09"));
+        assertThat(foundUser.getBirthTime()).isEqualTo(LocalTime.parse("08:30:00"));
+        assertThat(foundUser.getCalendarType()).isEqualTo(CalendarType.SOLAR);
+        assertThat(foundUser.getGender()).isEqualTo(Gender.MALE);
+    }
+
+    @Test
+    @DisplayName("UserPersistenceAdapter의 update 메서드가 DB의 사용자 정보를 올바르게 업데이트 한다.")
+    void update() {
+        // given
+        User user = new User(null, "홍길동",
+            LocalDate.parse("2025-02-09"),
+            LocalTime.parse("08:30:00"),
+            CalendarType.SOLAR,
+            Gender.MALE);
+        Long userId = userPersistenceAdapter.save(user);
+
+        // when
+        User updatedUser = new User(userId, "김철수",
+            LocalDate.parse("2025-03-10"),
+            LocalTime.parse("09:00:00"),
+            CalendarType.LUNAR,
+            Gender.MALE);
+        userPersistenceAdapter.update(updatedUser);
+
+        // then
+        Optional<User> optionalUser = userPersistenceAdapter.findById(userId);
+        assertThat(optionalUser).isPresent();
+        User foundUser = optionalUser.get();
+        assertThat(foundUser.getName()).isEqualTo("김철수");
+        assertThat(foundUser.getBirthDate()).isEqualTo(LocalDate.parse("2025-03-10"));
+        assertThat(foundUser.getBirthTime()).isEqualTo(LocalTime.parse("09:00:00"));
+        assertThat(foundUser.getCalendarType()).isEqualTo(CalendarType.LUNAR);
+        assertThat(foundUser.getGender()).isEqualTo(Gender.MALE);
+    }
+
+    @Test
+    @DisplayName("UserPersistenceAdapter의 update 메서드가 존재하지 않는 사용자를 업데이트하려 할 때 예외를 발생시킨다.")
+    void update_nonexistentUser_throwsException() {
+        // given
+        Long nonExistentId = 999L;
+        User updatedUser = new User(nonExistentId, "김철수",
+            LocalDate.parse("2025-03-10"),
+            LocalTime.parse("09:00:00"),
+            CalendarType.LUNAR,
+            Gender.MALE);
+
+        // when & then
+        assertThrows(UserNotFoundException.class, () -> {
+            userPersistenceAdapter.update(updatedUser);
+        });
     }
 }

--- a/src/test/java/co/yapp/orbit/user/application/SaveUserServiceTest.java
+++ b/src/test/java/co/yapp/orbit/user/application/SaveUserServiceTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import co.yapp.orbit.user.application.port.in.UserCommand;
+import co.yapp.orbit.user.application.port.in.SaveUserCommand;
 import co.yapp.orbit.user.application.port.out.SaveUserPort;
 import co.yapp.orbit.user.domain.User;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,7 +27,7 @@ class SaveUserServiceTest {
     @DisplayName("사용자 저장 시, 유효한 요청이면 생성된 사용자 id를 반환한다.")
     void saveUser_success() {
         // given
-        UserCommand command = new UserCommand("홍길동", "2025-02-09", "08:30:00", "SOLAR", "MALE");
+        SaveUserCommand command = new SaveUserCommand("홍길동", "2025-02-09", "08:30:00", "SOLAR", "MALE");
         Long expectedId = 1L;
         when(saveUserPort.save(any(User.class))).thenReturn(expectedId);
 

--- a/src/test/java/co/yapp/orbit/user/application/UpdateUserServiceTest.java
+++ b/src/test/java/co/yapp/orbit/user/application/UpdateUserServiceTest.java
@@ -1,0 +1,50 @@
+package co.yapp.orbit.user.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import co.yapp.orbit.user.application.port.in.UpdateUserCommand;
+import co.yapp.orbit.user.application.port.out.UpdateUserPort;
+import co.yapp.orbit.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class UpdateUserServiceTest {
+
+    private UpdateUserPort updateUserPort;
+    private UpdateUserService updateUserService;
+
+    @BeforeEach
+    void setUp() {
+        updateUserPort = Mockito.mock(UpdateUserPort.class);
+        updateUserService = new UpdateUserService(updateUserPort);
+    }
+
+    @Test
+    @DisplayName("사용자 수정 시, 유효한 요청이면 내부에 올바른 도메인 객체를 전달한다.")
+    void updateUser_success() {
+        // given
+        Long userId = 1L;
+        UpdateUserCommand command = new UpdateUserCommand("홍길동", "2025-02-09", "08:30:00", "SOLAR", "MALE");
+
+        // when
+        updateUserService.updateUser(userId, command);
+
+        // then
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(updateUserPort, times(1)).update(userCaptor.capture());
+        User capturedUser = userCaptor.getValue();
+        assertEquals(userId, capturedUser.getId());
+        assertEquals("홍길동", capturedUser.getName());
+        assertEquals(LocalDate.parse("2025-02-09"), capturedUser.getBirthDate());
+        assertEquals(LocalTime.parse("08:30:00"), capturedUser.getBirthTime());
+        assertEquals("SOLAR", capturedUser.getCalendarType().toString());
+        assertEquals("MALE", capturedUser.getGender().toString());
+    }
+}


### PR DESCRIPTION
## Related issue 🛠
[//]: # (해당하는 이슈 번호 달아주기)
closed #<issue_number>

어떤 변경사항이 있었나요?
- [ ] 🐞 BugFix Something isn't working
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [ ] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (Junit, etc.)

## CheckPoint ✅
[//]: # (PR 요구사항 확인)
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] PR 컨벤션에 맞게 작성했습니다. (필수)
- [x] merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- [x] Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.
- [x] BugFix의 경우, 버그의 원인을 파악하였습니다. (선택)

## Work Description ✏️
[//]: # (작업 내용 간단 소개)
- 사용자 정보를 업데이트하는 API를 새로 구현하였습니다.
- 클라이언트가 전달하는 전체 사용자 정보를 기반으로 기존 데이터를 완전히 덮어쓰도록 구현했습니다.
- 입력 데이터에 대한 유효성 검사와 변환 로직(예: 태어난 시간이 null 또는 빈 문자열인 경우 null 처리)을 포함하여 서비스 계층에서 처리하도록 변경했습니다.
- API 문서화 및 관련 테스트 코드(단위 테스트, 통합 테스트)도 함께 추가되었습니다.

## Uncompleted Tasks 😅
[//]: # (없다면 N/A)
- [ ] Task1

## To Reviewers 📢
[//]: # (reviewer가 알면 좋은 내용들)
- GitHub Actions 환경에서 실행할 때 `birthDate` 필드에 대한 검증이 실패하는 문제 발생
  - 로컬 환경과 GitHub Actions의 기본 타임존 설정 차이로 인해 발생하는 현상
  - pr-action 수정 필요